### PR TITLE
feat: access key operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Run `tigris help` to see all available commands, or `tigris <command> help` for 
 ### Resources
 
 - `tigris organizations` - Manage organizations
+- `tigris access-keys` - Manage access keys
+- `tigris credentials` - Manage and test credentials
 - `tigris buckets` - Manage buckets
 - `tigris forks` - Manage forks
 - `tigris snapshots` - Manage snapshots
@@ -236,6 +238,73 @@ tigris organizations create <name>
 tigris organizations select <name>
 ```
 
+### `access-keys` | `keys`
+
+Manage access keys
+
+| Command | Description |
+|---------|-------------|
+| `access-keys list` (l) | List all access keys |
+| `access-keys create` (c) | Create a new access key |
+| `access-keys delete` (d) | Delete an access key |
+| `access-keys get` (g) | Get details of an access key |
+| `access-keys assign` (a) | Assign bucket roles to an access key |
+
+#### `access-keys list`
+
+```
+tigris access-keys list
+```
+
+#### `access-keys create`
+
+```
+tigris access-keys create <name>
+```
+
+#### `access-keys delete`
+
+```
+tigris access-keys delete <id>
+```
+
+#### `access-keys get`
+
+```
+tigris access-keys get <id>
+```
+
+#### `access-keys assign`
+
+```
+tigris access-keys assign <id> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-b, --bucket` | Bucket name (can specify multiple) |
+| `-r, --role` | Role to assign (can specify multiple to pair with buckets) |
+| `--admin` | Grant admin access to all buckets in the organization |
+| `--revoke-roles` | Revoke all bucket roles from the access key |
+
+### `credentials` | `creds`
+
+Manage and test credentials
+
+| Command | Description |
+|---------|-------------|
+| `credentials test` (t) | Test if credentials have access to Tigris (optionally to a specific bucket) |
+
+#### `credentials test`
+
+```
+tigris credentials test [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-b, --bucket` | Bucket name to test access against (optional) |
+
 ### Buckets
 
 Buckets are containers for objects. You can also create forks and snapshots of buckets.
@@ -250,6 +319,7 @@ Manage buckets
 | `buckets create` (c) | Create bucket |
 | `buckets get` (g) | Get bucket details |
 | `buckets delete` (d) | Delete bucket |
+| `buckets set` (s) | Update bucket settings |
 
 ##### `buckets list`
 
@@ -286,6 +356,22 @@ tigris buckets get <name>
 ```
 tigris buckets delete <name>
 ```
+
+##### `buckets set`
+
+```
+tigris buckets set <name> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--access` | Bucket access level |
+| `--region` | Allowed regions (can specify multiple) |
+| `--allow-object-acl` | Enable object-level ACL |
+| `--disable-directory-listing` | Disable directory listing |
+| `--cache-control` | Default cache-control header value |
+| `--custom-domain` | Custom domain for the bucket |
+| `--enable-delete-protection` | Enable delete protection |
 
 #### `forks` | `f`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.908.0",
-        "@tigrisdata/iam": "^1.0.0",
-        "@tigrisdata/storage": "^2.11.0",
+        "@tigrisdata/iam": "^1.1.0",
+        "@tigrisdata/storage": "^2.12.0",
         "axios": "^1.12.2",
         "commander": "^11.0.0",
         "enquirer": "^2.4.1",
@@ -4240,18 +4240,18 @@
       "license": "MIT"
     },
     "node_modules/@tigrisdata/iam": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/iam/-/iam-1.0.0.tgz",
-      "integrity": "sha512-mWAx0RNxKajRXxNHMgcbBDUHLXpCO3HVgRk9VEo+H/k1s4KVnorsLUVq6zJNamkbxZ4riFNdyXgqJ8Ta9GnRWA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/iam/-/iam-1.1.0.tgz",
+      "integrity": "sha512-5cwjN5G2ygnbL0Fcwrtxujjxlo4W7wJFHXVhTT9kWlItj2kWNy/XPgbuoteUeQXDKiIr9c/+C03mA3pKWVfdmQ==",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.2.1"
       }
     },
     "node_modules/@tigrisdata/storage": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-2.11.0.tgz",
-      "integrity": "sha512-3GQm3VR/E9UY7oqWyO34O38y3x1PDpxGR4fc9of3rFtRzPdtYB2WbPmEAYK2weu9FuKrPbgZ19faY32Yi9I0mQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-2.12.0.tgz",
+      "integrity": "sha512-hZ/aYdFRkBugYkzbQ+uM1rTM1BRFHFDsGemEg8O9Rl00NKZwRHq0k+xEAmUvCyJhItMlZozGLXwUW9pJPKTYUQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -7845,16 +7845,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8328,9 +8328,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.7.0.tgz",
-      "integrity": "sha512-wiCZpv/41bIobCoJ31NStIWKfAxxYyD1iYnWCtiyns8s5v3+l8y0HCP/sScuH6B5+GhIfda4HQKiqeGZwJWhFw==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.8.0.tgz",
+      "integrity": "sha512-n19sJeW+RGKdkHo8SCc5xhSwkKhQUFfZaFzSc+EsYXLjSqIV0tl72aDYQVuzVvfrbysGwdaQsNLNy58J10EBSQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -8410,8 +8410,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.9",
-        "@npmcli/config": "^10.4.5",
+        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/config": "^10.5.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -8419,7 +8419,7 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.3",
-        "@sigstore/tuf": "^4.0.0",
+        "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
         "cacache": "^20.0.3",
@@ -8436,11 +8436,11 @@
         "is-cidr": "^6.0.1",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.12",
-        "libnpmexec": "^10.1.11",
-        "libnpmfund": "^7.0.12",
+        "libnpmdiff": "^8.0.13",
+        "libnpmexec": "^10.1.12",
+        "libnpmfund": "^7.0.13",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.12",
+        "libnpmpack": "^9.0.13",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -8469,11 +8469,11 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.0",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.2",
+        "tar": "^7.5.4",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^7.0.0",
+        "validate-npm-package-name": "^7.0.2",
         "which": "^6.0.0"
       },
       "bin": {
@@ -8629,7 +8629,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.9",
+      "version": "9.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8647,7 +8647,7 @@
         "@npmcli/run-script": "^10.0.0",
         "bin-links": "^6.0.0",
         "cacache": "^20.0.1",
-        "common-ancestor-path": "^1.0.1",
+        "common-ancestor-path": "^2.0.0",
         "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
         "lru-cache": "^11.2.1",
@@ -8676,7 +8676,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.4.5",
+      "version": "10.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8871,7 +8871,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -8889,52 +8889,43 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.0.1",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.2",
-        "proc-log": "^5.0.0",
+        "make-fetch-happen": "^15.0.3",
+        "proc-log": "^6.1.0",
         "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0",
-        "tuf-js": "^4.0.0"
+        "tuf-js": "^4.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -8951,31 +8942,16 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
+        "minimatch": "^10.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
@@ -9020,7 +8996,6 @@
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
@@ -9054,7 +9029,6 @@
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -9153,10 +9127,13 @@
       }
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
@@ -9188,7 +9165,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -9383,7 +9360,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9486,12 +9463,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.12",
+      "version": "8.0.13",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.1.10",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -9505,12 +9482,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.11",
+      "version": "10.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.1.10",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -9528,12 +9505,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.12",
+      "version": "7.0.13",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9"
+        "@npmcli/arborist": "^9.1.10"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -9553,12 +9530,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.12",
+      "version": "9.0.13",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.1.10",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -9628,10 +9605,10 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.2",
+      "version": "11.2.4",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -10042,7 +10019,7 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10058,7 +10035,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10201,17 +10178,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "@sigstore/verify": "^3.0.0"
+        "@sigstore/sign": "^4.1.0",
+        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/verify": "^3.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10348,7 +10325,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.2",
+      "version": "7.5.4",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10439,14 +10416,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "4.0.0",
-        "debug": "^4.4.1",
-        "make-fetch-happen": "^15.0.0"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -10503,7 +10480,7 @@
       }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13468,9 +13445,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
+      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.908.0",
-    "@tigrisdata/iam": "^1.0.0",
-    "@tigrisdata/storage": "^2.11.0",
+    "@tigrisdata/iam": "^1.1.0",
+    "@tigrisdata/storage": "^2.12.0",
     "axios": "^1.12.2",
     "commander": "^11.0.0",
     "enquirer": "^2.4.1",

--- a/scripts/update-docs.ts
+++ b/scripts/update-docs.ts
@@ -189,7 +189,7 @@ function generateDocs(specs: Specs): string {
   lines.push('');
 
   // Resource management
-  const resourceCommands = ['organizations', 'buckets', 'forks', 'snapshots', 'objects'];
+  const resourceCommands = ['organizations', 'access-keys', 'credentials', 'buckets', 'forks', 'snapshots', 'objects'];
   const implementedResources = resourceCommands.filter((c) => {
     const cmd = specs.commands.find((s) => s.name === c);
     return cmd?.operations?.some((op) => isImplemented(c, op.name));
@@ -240,6 +240,22 @@ function generateDocs(specs: Specs): string {
     const orgsCmd = specs.commands.find((c) => c.name === 'organizations');
     if (orgsCmd) {
       lines.push(generateResourceSection(orgsCmd));
+    }
+  }
+
+  // Access Keys
+  if (implementedResources.includes('access-keys')) {
+    const accessKeysCmd = specs.commands.find((c) => c.name === 'access-keys');
+    if (accessKeysCmd) {
+      lines.push(generateResourceSection(accessKeysCmd));
+    }
+  }
+
+  // Credentials
+  if (implementedResources.includes('credentials')) {
+    const credentialsCmd = specs.commands.find((c) => c.name === 'credentials');
+    if (credentialsCmd) {
+      lines.push(generateResourceSection(credentialsCmd));
     }
   }
 

--- a/src/lib/access-keys/assign.ts
+++ b/src/lib/access-keys/assign.ts
@@ -1,0 +1,153 @@
+import { getOption } from '../../utils/options.js';
+import { getLoginMethod } from '../../auth/s3-client.js';
+import { getAuthClient } from '../../auth/client.js';
+import { getSelectedOrganization } from '../../auth/storage.js';
+import { getTigrisConfig } from '../../auth/config.js';
+import { assignBucketRoles, revokeAllBucketRoles } from '@tigrisdata/iam';
+import {
+  printStart,
+  printSuccess,
+  printFailure,
+  msg,
+} from '../../utils/messages.js';
+
+const context = msg('access-keys', 'assign');
+
+type Role = 'Editor' | 'ReadOnly' | 'NamespaceAdmin';
+const validRoles: Role[] = ['Editor', 'ReadOnly', 'NamespaceAdmin'];
+
+function normalizeToArray<T>(value: T | T[] | undefined): T[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+export default async function assign(options: Record<string, unknown>) {
+  printStart(context);
+
+  const id = getOption<string>(options, ['id']);
+  const admin = getOption<boolean>(options, ['admin']);
+  const revokeRoles = getOption<boolean>(options, [
+    'revokeRoles',
+    'revoke-roles',
+  ]);
+  const buckets = normalizeToArray(
+    getOption<string | string[]>(options, ['bucket', 'b'])
+  );
+  const roles = normalizeToArray(
+    getOption<string | string[]>(options, ['role', 'r'])
+  );
+
+  if (!id) {
+    printFailure(context, 'Access key ID is required');
+    process.exit(1);
+  }
+
+  if (admin && revokeRoles) {
+    printFailure(context, 'Cannot use --admin and --revoke-roles together');
+    process.exit(1);
+  }
+
+  const loginMethod = await getLoginMethod();
+
+  if (loginMethod !== 'oauth') {
+    printFailure(
+      context,
+      'Bucket roles can only be managed when logged in via OAuth.\nRun "tigris login oauth" first.'
+    );
+    process.exit(1);
+  }
+
+  const authClient = getAuthClient();
+  const isAuthenticated = await authClient.isAuthenticated();
+
+  if (!isAuthenticated) {
+    printFailure(context, 'Not authenticated. Run "tigris login oauth" first.');
+    process.exit(1);
+  }
+
+  const accessToken = await authClient.getAccessToken();
+  const selectedOrg = getSelectedOrganization();
+  const tigrisConfig = getTigrisConfig();
+
+  const config = {
+    sessionToken: accessToken,
+    organizationId: selectedOrg ?? undefined,
+    iamEndpoint: tigrisConfig.iamEndpoint,
+  };
+
+  if (revokeRoles) {
+    const { error } = await revokeAllBucketRoles(id, { config });
+
+    if (error) {
+      printFailure(context, error.message);
+      process.exit(1);
+    }
+
+    printSuccess(context);
+    return;
+  }
+
+  let assignments: { bucket: string; role: Role }[];
+
+  if (admin) {
+    // Admin access: grant NamespaceAdmin to all buckets
+    assignments = [{ bucket: '*', role: 'NamespaceAdmin' }];
+  } else {
+    if (buckets.length === 0) {
+      printFailure(
+        context,
+        'At least one bucket name is required (or use --admin or --revoke-roles)'
+      );
+      process.exit(1);
+    }
+
+    if (roles.length === 0) {
+      printFailure(
+        context,
+        'At least one role is required (or use --admin or --revoke-roles)'
+      );
+      process.exit(1);
+    }
+
+    // Validate all roles
+    for (const role of roles) {
+      if (!validRoles.includes(role as Role)) {
+        printFailure(
+          context,
+          `Invalid role "${role}". Valid roles are: ${validRoles.join(', ')}`
+        );
+        process.exit(1);
+      }
+    }
+
+    // Build role assignments
+    if (roles.length === 1) {
+      // Single role applies to all buckets
+      assignments = buckets.map((bucket) => ({
+        bucket,
+        role: roles[0] as Role,
+      }));
+    } else if (roles.length === buckets.length) {
+      // Pair buckets with roles
+      assignments = buckets.map((bucket, i) => ({
+        bucket,
+        role: roles[i] as Role,
+      }));
+    } else {
+      printFailure(
+        context,
+        `Number of roles (${roles.length}) must be 1 or match number of buckets (${buckets.length})`
+      );
+      process.exit(1);
+    }
+  }
+
+  const { error } = await assignBucketRoles(id, assignments, { config });
+
+  if (error) {
+    printFailure(context, error.message);
+    process.exit(1);
+  }
+
+  printSuccess(context);
+}

--- a/src/lib/access-keys/create.ts
+++ b/src/lib/access-keys/create.ts
@@ -1,0 +1,70 @@
+import { getOption } from '../../utils/options.js';
+import { getLoginMethod } from '../../auth/s3-client.js';
+import { getAuthClient } from '../../auth/client.js';
+import { getSelectedOrganization } from '../../auth/storage.js';
+import { getTigrisConfig } from '../../auth/config.js';
+import { createAccessKey } from '@tigrisdata/iam';
+import {
+  printStart,
+  printSuccess,
+  printFailure,
+  msg,
+} from '../../utils/messages.js';
+
+const context = msg('access-keys', 'create');
+
+export default async function create(options: Record<string, unknown>) {
+  printStart(context);
+
+  const name = getOption<string>(options, ['name']);
+
+  if (!name) {
+    printFailure(context, 'Access key name is required');
+    process.exit(1);
+  }
+
+  const loginMethod = await getLoginMethod();
+
+  if (loginMethod !== 'oauth') {
+    printFailure(
+      context,
+      'Access keys can only be created when logged in via OAuth.\nRun "tigris login oauth" first.'
+    );
+    process.exit(1);
+  }
+
+  const authClient = getAuthClient();
+  const isAuthenticated = await authClient.isAuthenticated();
+
+  if (!isAuthenticated) {
+    printFailure(context, 'Not authenticated. Run "tigris login oauth" first.');
+    process.exit(1);
+  }
+
+  const accessToken = await authClient.getAccessToken();
+  const selectedOrg = getSelectedOrganization();
+  const tigrisConfig = getTigrisConfig();
+
+  const { data, error } = await createAccessKey(name, {
+    config: {
+      sessionToken: accessToken,
+      organizationId: selectedOrg ?? undefined,
+      iamEndpoint: tigrisConfig.iamEndpoint,
+    },
+  });
+
+  if (error) {
+    printFailure(context, error.message);
+    process.exit(1);
+  }
+
+  console.log(`  Name: ${data.name}`);
+  console.log(`  Access Key ID: ${data.id}`);
+  console.log(`  Secret Access Key: ${data.secret}`);
+  console.log('');
+  console.log(
+    '  Save these credentials securely. The secret will not be shown again.'
+  );
+
+  printSuccess(context);
+}

--- a/src/lib/access-keys/delete.ts
+++ b/src/lib/access-keys/delete.ts
@@ -1,0 +1,62 @@
+import { getOption } from '../../utils/options.js';
+import { getLoginMethod } from '../../auth/s3-client.js';
+import { getAuthClient } from '../../auth/client.js';
+import { getSelectedOrganization } from '../../auth/storage.js';
+import { getTigrisConfig } from '../../auth/config.js';
+import { removeAccessKey } from '@tigrisdata/iam';
+import {
+  printStart,
+  printSuccess,
+  printFailure,
+  msg,
+} from '../../utils/messages.js';
+
+const context = msg('access-keys', 'delete');
+
+export default async function remove(options: Record<string, unknown>) {
+  printStart(context);
+
+  const id = getOption<string>(options, ['id']);
+
+  if (!id) {
+    printFailure(context, 'Access key ID is required');
+    process.exit(1);
+  }
+
+  const loginMethod = await getLoginMethod();
+
+  if (loginMethod !== 'oauth') {
+    printFailure(
+      context,
+      'Access keys can only be deleted when logged in via OAuth.\nRun "tigris login oauth" first.'
+    );
+    process.exit(1);
+  }
+
+  const authClient = getAuthClient();
+  const isAuthenticated = await authClient.isAuthenticated();
+
+  if (!isAuthenticated) {
+    printFailure(context, 'Not authenticated. Run "tigris login oauth" first.');
+    process.exit(1);
+  }
+
+  const accessToken = await authClient.getAccessToken();
+  const selectedOrg = getSelectedOrganization();
+  const tigrisConfig = getTigrisConfig();
+
+  const { error } = await removeAccessKey(id, {
+    config: {
+      sessionToken: accessToken,
+      organizationId: selectedOrg ?? undefined,
+      iamEndpoint: tigrisConfig.iamEndpoint,
+    },
+  });
+
+  if (error) {
+    printFailure(context, error.message);
+    process.exit(1);
+  }
+
+  printSuccess(context);
+}

--- a/src/lib/access-keys/get.ts
+++ b/src/lib/access-keys/get.ts
@@ -1,0 +1,77 @@
+import { getOption } from '../../utils/options.js';
+import { getLoginMethod } from '../../auth/s3-client.js';
+import { getAuthClient } from '../../auth/client.js';
+import { getSelectedOrganization } from '../../auth/storage.js';
+import { getTigrisConfig } from '../../auth/config.js';
+import { getAccessKey } from '@tigrisdata/iam';
+import {
+  printStart,
+  printSuccess,
+  printFailure,
+  msg,
+} from '../../utils/messages.js';
+
+const context = msg('access-keys', 'get');
+
+export default async function get(options: Record<string, unknown>) {
+  printStart(context);
+
+  const id = getOption<string>(options, ['id']);
+
+  if (!id) {
+    printFailure(context, 'Access key ID is required');
+    process.exit(1);
+  }
+
+  const loginMethod = await getLoginMethod();
+
+  if (loginMethod !== 'oauth') {
+    printFailure(
+      context,
+      'Access keys can only be retrieved when logged in via OAuth.\nRun "tigris login oauth" first.'
+    );
+    process.exit(1);
+  }
+
+  const authClient = getAuthClient();
+  const isAuthenticated = await authClient.isAuthenticated();
+
+  if (!isAuthenticated) {
+    printFailure(context, 'Not authenticated. Run "tigris login oauth" first.');
+    process.exit(1);
+  }
+
+  const accessToken = await authClient.getAccessToken();
+  const selectedOrg = getSelectedOrganization();
+  const tigrisConfig = getTigrisConfig();
+
+  const { data, error } = await getAccessKey(id, {
+    config: {
+      sessionToken: accessToken,
+      organizationId: selectedOrg ?? undefined,
+      iamEndpoint: tigrisConfig.iamEndpoint,
+    },
+  });
+
+  if (error) {
+    printFailure(context, error.message);
+    process.exit(1);
+  }
+
+  console.log(`  Name: ${data.name}`);
+  console.log(`  ID: ${data.id}`);
+  console.log(`  Status: ${data.status}`);
+  console.log(`  Created: ${data.createdAt}`);
+  console.log(`  Organization: ${data.organizationId}`);
+
+  if (data.roles && data.roles.length > 0) {
+    console.log(`  Roles:`);
+    for (const role of data.roles) {
+      console.log(`    - ${role.bucket}: ${role.role}`);
+    }
+  } else {
+    console.log(`  Roles: None`);
+  }
+
+  printSuccess(context);
+}

--- a/src/lib/access-keys/list.ts
+++ b/src/lib/access-keys/list.ts
@@ -1,0 +1,76 @@
+import { formatOutput } from '../../utils/format.js';
+import { getLoginMethod } from '../../auth/s3-client.js';
+import { getAuthClient } from '../../auth/client.js';
+import { getSelectedOrganization } from '../../auth/storage.js';
+import { getTigrisConfig } from '../../auth/config.js';
+import { listAccessKeys } from '@tigrisdata/iam';
+import {
+  printStart,
+  printSuccess,
+  printFailure,
+  printEmpty,
+  msg,
+} from '../../utils/messages.js';
+
+const context = msg('access-keys', 'list');
+
+export default async function list() {
+  printStart(context);
+
+  const loginMethod = await getLoginMethod();
+
+  if (loginMethod !== 'oauth') {
+    printFailure(
+      context,
+      'Access keys can only be listed when logged in via OAuth.\nRun "tigris login oauth" first.'
+    );
+    process.exit(1);
+  }
+
+  const authClient = getAuthClient();
+  const isAuthenticated = await authClient.isAuthenticated();
+
+  if (!isAuthenticated) {
+    printFailure(context, 'Not authenticated. Run "tigris login oauth" first.');
+    process.exit(1);
+  }
+
+  const accessToken = await authClient.getAccessToken();
+  const selectedOrg = getSelectedOrganization();
+  const tigrisConfig = getTigrisConfig();
+
+  const { data, error } = await listAccessKeys({
+    config: {
+      sessionToken: accessToken,
+      organizationId: selectedOrg ?? undefined,
+      iamEndpoint: tigrisConfig.iamEndpoint,
+    },
+  });
+
+  if (error) {
+    printFailure(context, error.message);
+    process.exit(1);
+  }
+
+  if (!data.accessKeys || data.accessKeys.length === 0) {
+    printEmpty(context);
+    return;
+  }
+
+  const keys = data.accessKeys.map((key) => ({
+    name: key.name,
+    id: key.id,
+    status: key.status,
+    created: key.createdAt,
+  }));
+
+  const output = formatOutput(keys, 'table', 'keys', 'key', [
+    { key: 'name', header: 'Name' },
+    { key: 'id', header: 'ID' },
+    { key: 'status', header: 'Status' },
+    { key: 'created', header: 'Created' },
+  ]);
+
+  console.log(output);
+  printSuccess(context, { count: keys.length });
+}

--- a/src/specs.yaml
+++ b/src/specs.yaml
@@ -189,6 +189,85 @@ commands:
             alias: b
             required: false
 
+  # access-keys
+  - name: access-keys
+    description: Manage access keys
+    alias: keys
+    operations:
+      - name: list
+        description: List all access keys
+        alias: l
+        messages:
+          onStart: ''
+          onSuccess: ''
+          onFailure: 'Failed to list access keys'
+          onEmpty: 'No access keys found'
+      - name: create
+        description: Create a new access key
+        alias: c
+        messages:
+          onStart: 'Creating access key...'
+          onSuccess: 'Access key created'
+          onFailure: 'Failed to create access key'
+        arguments:
+          - name: name
+            description: Name for the access key
+            type: positional
+            required: true
+      - name: delete
+        description: Delete an access key
+        alias: d
+        messages:
+          onStart: 'Deleting access key...'
+          onSuccess: 'Access key deleted'
+          onFailure: 'Failed to delete access key'
+        arguments:
+          - name: id
+            description: Access key ID
+            type: positional
+            required: true
+      - name: get
+        description: Get details of an access key
+        alias: g
+        messages:
+          onStart: ''
+          onSuccess: ''
+          onFailure: 'Failed to get access key'
+        arguments:
+          - name: id
+            description: Access key ID
+            type: positional
+            required: true
+      - name: assign
+        description: Assign bucket roles to an access key
+        alias: a
+        messages:
+          onStart: 'Assigning bucket roles...'
+          onSuccess: 'Bucket roles assigned'
+          onFailure: 'Failed to assign bucket roles'
+        arguments:
+          - name: id
+            description: Access key ID
+            type: positional
+            required: true
+          - name: bucket
+            alias: b
+            description: Bucket name (can specify multiple)
+            multiple: true
+          - name: role
+            alias: r
+            description: Role to assign (can specify multiple to pair with buckets)
+            multiple: true
+            options:
+              - Editor
+              - ReadOnly
+          - name: admin
+            description: Grant admin access to all buckets in the organization
+            type: flag
+          - name: revoke-roles
+            description: Revoke all bucket roles from the access key
+            type: flag
+
   #########################
   # Unix style commands
   #########################


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds new `access-keys` CLI resource and updates docs/specs to surface it alongside credentials and buckets.
> 
> - Implement `access-keys` commands: `list`, `create`, `delete`, `get`, and `assign` (supports `--bucket`, `--role`, `--admin`, `--revoke-roles`), all OAuth-gated
> - Extend `scripts/update-docs.ts` and `src/specs.yaml` to document new commands; README updated accordingly
> - Add `buckets set` documentation section for updating bucket settings
> - Bump SDK deps to `@tigrisdata/iam@^1.1.0` and `@tigrisdata/storage@^2.12.0`; lockfile refresh with minor transitive updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd69f6f39001e43f24f629332fd875895b025cc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->