### PR TITLE
fix: use auto-merge for sync PR to respect approval requirement

### DIFF
--- a/.github/workflows/sync-release-to-main.yaml
+++ b/.github/workflows/sync-release-to-main.yaml
@@ -43,12 +43,12 @@ jobs:
               --body "Automated sync of release tags back to main."
           fi
 
-      - name: Auto-merge sync PR
+      - name: Enable auto-merge on sync PR
         if: steps.check.outputs.ahead != '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR=$(gh pr list --repo ${{ github.repository }} --base main --head release --state open --json number --jq '.[0].number')
           if [ -n "$PR" ]; then
-            gh pr merge "$PR" --repo ${{ github.repository }} --merge
+            gh pr merge "$PR" --repo ${{ github.repository }} --merge --auto
           fi


### PR DESCRIPTION
## Summary
- Changes sync workflow to use `--auto` flag instead of immediate merge
- The sync PR is created and queued for auto-merge after approval
- Fixes the failed sync run where `gh pr merge` was blocked by the 1-approval requirement on `main`

## Test plan
- After next stable release, verify sync PR is created with auto-merge enabled
- Approve the PR to trigger the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that alters how the sync PR is merged; main impact is operational (PRs now wait for required approvals before merging).
> 
> **Overview**
> Updates the `sync-release-to-main` GitHub Actions workflow to **enable auto-merge** for the release-to-main sync PR instead of merging immediately.
> 
> The `gh pr merge` invocation now uses `--auto`, so the sync PR is queued and merges only after branch protection requirements (e.g., required approvals) are satisfied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d9cd7f76a5e75a95099ebf5a22c618a95dafb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->