### PR TITLE
fix: improve update command resolution and restrict brew updates to stable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,7 +150,7 @@ jobs:
 
   update-homebrew:
     needs: [release, build-binaries]
-    if: needs.release.outputs.new_release_published == 'true'
+    if: needs.release.outputs.new_release_published == 'true' && github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
 
     steps:

--- a/src/utils/update-check.ts
+++ b/src/utils/update-check.ts
@@ -1,5 +1,4 @@
-import { execSync } from 'child_process';
-import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from 'fs';
 import https from 'https';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -96,8 +95,8 @@ export function isNewerVersion(current: string, latest: string): boolean {
 function isHomebrewInstall(): boolean {
   if (process.platform === 'win32') return false;
   try {
-    execSync('brew list tigris', { stdio: 'ignore' });
-    return true;
+    const resolved = realpathSync(process.execPath);
+    return resolved.includes('/Cellar/') || resolved.includes('/Caskroom/');
   } catch {
     return false;
   }
@@ -107,15 +106,16 @@ function isHomebrewInstall(): boolean {
  * Returns the platform-appropriate shell command for updating the CLI.
  */
 export function getUpdateCommand(): string {
+  if (isHomebrewInstall()) {
+    return 'brew upgrade tigris';
+  }
+
   const isBinary =
     (globalThis as { __TIGRIS_BINARY?: boolean }).__TIGRIS_BINARY === true;
-  const isWindows = process.platform === 'win32';
 
   if (!isBinary) {
     return 'npm install -g @tigrisdata/cli';
-  } else if (isHomebrewInstall()) {
-    return 'brew upgrade tigris';
-  } else if (isWindows) {
+  } else if (process.platform === 'win32') {
     return 'irm https://github.com/tigrisdata/cli/releases/latest/download/install.ps1 | iex';
   } else {
     return 'curl -fsSL https://github.com/tigrisdata/cli/releases/latest/download/install.sh | sh';

--- a/src/utils/update-check.ts
+++ b/src/utils/update-check.ts
@@ -106,18 +106,25 @@ function isHomebrewInstall(): boolean {
  * Returns the platform-appropriate shell command for updating the CLI.
  */
 export function getUpdateCommand(): string {
-  if (isHomebrewInstall()) {
-    return 'brew upgrade tigris';
-  }
-
   const isBinary =
     (globalThis as { __TIGRIS_BINARY?: boolean }).__TIGRIS_BINARY === true;
 
+  // npm install — process.execPath is Node, not our binary.
+  // Must come before isHomebrewInstall() to avoid false positives
+  // when Node itself was installed via Homebrew.
   if (!isBinary) {
     return 'npm install -g @tigrisdata/cli';
-  } else if (process.platform === 'win32') {
+  }
+  // Standalone binary installed via Homebrew (execPath resolves to /Cellar/ or /Caskroom/)
+  else if (isHomebrewInstall()) {
+    return 'brew upgrade tigris';
+  }
+  // Standalone binary on Windows
+  else if (process.platform === 'win32') {
     return 'irm https://github.com/tigrisdata/cli/releases/latest/download/install.ps1 | iex';
-  } else {
+  }
+  // Standalone binary on macOS/Linux (installed via curl)
+  else {
     return 'curl -fsSL https://github.com/tigrisdata/cli/releases/latest/download/install.sh | sh';
   }
 }


### PR DESCRIPTION
## Summary
- Replace `execSync('brew list tigris')` with `realpathSync(process.execPath)` for Homebrew detection — faster (no subprocess) and correctly identifies *this* binary's install method
- Restrict `update-homebrew` workflow job to only run on the `release` branch, preventing beta releases (via `workflow_dispatch`) from updating the Homebrew formula

## Test plan
- [ ] Verify `getUpdateCommand()` returns `brew upgrade tigris` when running from a Homebrew-installed binary
- [ ] Verify `getUpdateCommand()` returns curl/npm commands for non-Homebrew installs
- [ ] Verify `update-homebrew` job is skipped on `workflow_dispatch` runs
- [ ] Verify `update-homebrew` job runs on pushes to `release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI’s update-path detection and alters release automation conditions, which could impact the upgrade instructions shown to users and when the Homebrew formula is updated. Scope is small but affects distribution/update behavior.
> 
> **Overview**
> Improves how the CLI decides which self-update command to suggest by detecting Homebrew installs via `realpathSync(process.execPath)` instead of running `brew`, and by ordering checks to avoid misclassifying npm installs when Node itself comes from Homebrew.
> 
> Restricts the `update-homebrew` GitHub Actions job to only run for releases on the `release` branch, preventing `workflow_dispatch`/non-branch runs from updating the Homebrew formula.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e6fcc567a2f2fc3cb564391b7177c618e69d601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->