### PR TITLE
docs: regenerate README to pick up buckets migrate and ls --source

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ List all buckets (no arguments) or objects under a bucket/prefix path. Accepts b
 tigris ls [path] [flags]
 ```
 
-| Flag                            | Description                                                                                                                                   |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-snapshot, --snapshot-version` | Read from a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
-| `--format`                      | Output format                                                                                                                                 |
-| `--limit`                       | Maximum number of items to return per page                                                                                                    |
-| `-pt, --page-token`             | Pagination token from a previous request to fetch the next page                                                                               |
+| `--format` | Output format |
+| `--limit` | Maximum number of items to return per page |
+| `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
+| `--source` | List objects from a specific storage source on buckets with shadow migration enabled |
 
 **Examples:**
-
 ```bash
 tigris ls
 tigris ls my-bucket
@@ -92,20 +92,19 @@ Create a bucket (bare name) or a folder inside a bucket (bucket/folder/ with tra
 tigris mk <path> [flags]
 ```
 
-| Flag                              | Description                                                                                                                                                                     |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-a, --access`                    | Access level (only applies when creating a bucket)                                                                                                                              |
-| `--public`                        | Shorthand for --access public (only applies when creating a bucket)                                                                                                             |
-| `-s, --enable-snapshots`          | Enable snapshots for the bucket (only applies when creating a bucket)                                                                                                           |
-| `-t, --default-tier`              | Default storage tier (only applies when creating a bucket)                                                                                                                      |
-| `-c, --consistency`               | (Deprecated, use --locations) Consistency level (only applies when creating a bucket)                                                                                           |
-| `-r, --region`                    | (Deprecated, use --locations) Region (only applies when creating a bucket)                                                                                                      |
-| `-l, --locations`                 | Location for the bucket (only applies when creating a bucket)                                                                                                                   |
-| `-fork, --fork-of`                | Create this bucket as a fork (copy-on-write clone) of the named source bucket                                                                                                   |
+| Flag | Description |
+|------|-------------|
+| `-a, --access` | Access level (only applies when creating a bucket) |
+| `--public` | Shorthand for --access public (only applies when creating a bucket) |
+| `-s, --enable-snapshots` | Enable snapshots for the bucket (only applies when creating a bucket) |
+| `-t, --default-tier` | Default storage tier (only applies when creating a bucket) |
+| `-c, --consistency` | (Deprecated, use --locations) Consistency level (only applies when creating a bucket) |
+| `-r, --region` | (Deprecated, use --locations) Region (only applies when creating a bucket) |
+| `-l, --locations` | Location for the bucket (only applies when creating a bucket) |
+| `-fork, --fork-of` | Create this bucket as a fork (copy-on-write clone) of the named source bucket |
 | `-source-snap, --source-snapshot` | Fork from a specific snapshot of the source bucket. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464). Requires --fork-of |
 
 **Examples:**
-
 ```bash
 tigris mk my-bucket
 tigris mk my-bucket --access public --region iad
@@ -124,7 +123,6 @@ tigris touch <path>
 ```
 
 **Examples:**
-
 ```bash
 tigris touch my-bucket/placeholder.txt
 tigris touch t3://my-bucket/logs/
@@ -138,12 +136,11 @@ Copy files between local filesystem and Tigris, or between paths within Tigris. 
 tigris cp <src> <dest> [flags]
 ```
 
-| Flag              | Description                  |
-| ----------------- | ---------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-r, --recursive` | Copy directories recursively |
 
 **Examples:**
-
 ```bash
 tigris cp ./file.txt t3://my-bucket/file.txt
 tigris cp t3://my-bucket/file.txt ./local-copy.txt
@@ -159,13 +156,12 @@ Move (rename) objects within Tigris. Both source and destination must be remote 
 tigris mv <src> <dest> [flags]
 ```
 
-| Flag              | Description                                 |
-| ----------------- | ------------------------------------------- |
-| `-r, --recursive` | Move directories recursively                |
-| `-f, --force`     | Skip confirmation prompts (alias for --yes) |
+| Flag | Description |
+|------|-------------|
+| `-r, --recursive` | Move directories recursively |
+| `-f, --force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris mv t3://my-bucket/old.txt t3://my-bucket/new.txt -f
 tigris mv t3://my-bucket/old-dir/ t3://my-bucket/new-dir/ -rf
@@ -180,13 +176,12 @@ Remove a bucket, folder, or object from Tigris. A bare bucket name deletes the b
 tigris rm <path> [flags]
 ```
 
-| Flag              | Description                                 |
-| ----------------- | ------------------------------------------- |
-| `-r, --recursive` | Remove directories recursively              |
-| `-f, --force`     | Skip confirmation prompts (alias for --yes) |
+| Flag | Description |
+|------|-------------|
+| `-r, --recursive` | Remove directories recursively |
+| `-f, --force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris rm t3://my-bucket/file.txt -f
 tigris rm t3://my-bucket/folder/ -rf
@@ -202,13 +197,12 @@ Show storage stats (no args), bucket info, or object metadata
 tigris stat [path] [flags]
 ```
 
-| Flag                            | Description                                                                                                                                   |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--format`                      | Output format                                                                                                                                 |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format |
 | `-snapshot, --snapshot-version` | Read from a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
 
 **Examples:**
-
 ```bash
 tigris stat
 tigris stat t3://my-bucket
@@ -223,16 +217,15 @@ Generate a presigned URL for temporary access to an object without credentials
 tigris presign <path> [flags]
 ```
 
-| Flag               | Description                                                                                   |
-| ------------------ | --------------------------------------------------------------------------------------------- |
-| `-m, --method`     | HTTP method for the presigned URL                                                             |
-| `-e, --expires-in` | URL expiry time in seconds                                                                    |
-| `--access-key`     | Access key ID to use for signing. If not provided, resolved from credentials or auto-selected |
-| `--select`         | Interactively select an access key (OAuth only)                                               |
-| `--format`         | Output format                                                                                 |
+| Flag | Description |
+|------|-------------|
+| `-m, --method` | HTTP method for the presigned URL |
+| `-e, --expires-in` | URL expiry time in seconds |
+| `--access-key` | Access key ID to use for signing. If not provided, resolved from credentials or auto-selected |
+| `--select` | Interactively select an access key (OAuth only) |
+| `--format` | Output format |
 
 **Examples:**
-
 ```bash
 tigris presign my-bucket/file.txt
 tigris presign t3://my-bucket/report.pdf --method put --expires-in 7200
@@ -248,15 +241,14 @@ Download multiple objects as a streaming tar archive in a single request. Design
 tigris bundle <bucket> [flags]
 ```
 
-| Flag            | Description                                                                                                                                                                   |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-k, --keys`    | Comma-separated object keys, or path to a file with one key per line. If a local file matching the value exists, it is read as a keys file. If omitted, reads keys from stdin |
-| `-o, --output`  | Output file path. Defaults to stdout (for piping)                                                                                                                             |
-| `--compression` | Compression algorithm for the archive. Auto-detected from output file extension when not specified                                                                            |
-| `--on-error`    | How to handle missing objects. 'skip' omits them, 'fail' aborts the request                                                                                                   |
+| Flag | Description |
+|------|-------------|
+| `-k, --keys` | Comma-separated object keys, or path to a file with one key per line. If a local file matching the value exists, it is read as a keys file. If omitted, reads keys from stdin |
+| `-o, --output` | Output file path. Defaults to stdout (for piping) |
+| `--compression` | Compression algorithm for the archive. Auto-detected from output file extension when not specified |
+| `--on-error` | How to handle missing objects. 'skip' omits them, 'fail' aborts the request |
 
 **Examples:**
-
 ```bash
 tigris bundle my-bucket --keys key1.jpg,key2.jpg --output archive.tar
 tigris bundle my-bucket --keys keys.txt --output archive.tar
@@ -270,10 +262,10 @@ cat keys.txt | tigris bundle my-bucket > archive.tar
 
 Start a session via OAuth (default) or temporary credentials. Session state is cleared on logout
 
-| Command                 | Description                                                                                |
-| ----------------------- | ------------------------------------------------------------------------------------------ |
-| `login select`          | Choose how to login - OAuth (browser) or credentials (access key)                          |
-| `login oauth` (o)       | Login via browser using OAuth2 device flow. Best for interactive use                       |
+| Command | Description |
+|---------|-------------|
+| `login select` | Choose how to login - OAuth (browser) or credentials (access key) |
+| `login oauth` (o) | Login via browser using OAuth2 device flow. Best for interactive use |
 | `login credentials` (c) | Login with an access key and secret. Creates a temporary session that is cleared on logout |
 
 #### `login select`
@@ -289,7 +281,6 @@ tigris login oauth
 ```
 
 **Examples:**
-
 ```bash
 tigris login oauth
 ```
@@ -300,13 +291,12 @@ tigris login oauth
 tigris login credentials [flags]
 ```
 
-| Flag                       | Description                                          |
-| -------------------------- | ---------------------------------------------------- |
-| `-key, --access-key`       | Your access key ID (will prompt if not provided)     |
+| Flag | Description |
+|------|-------------|
+| `-key, --access-key` | Your access key ID (will prompt if not provided) |
 | `-secret, --access-secret` | Your secret access key (will prompt if not provided) |
 
 **Examples:**
-
 ```bash
 tigris login credentials --access-key tid_AaBb --access-secret tsec_XxYy
 tigris login credentials
@@ -321,7 +311,6 @@ tigris logout
 ```
 
 **Examples:**
-
 ```bash
 tigris logout
 ```
@@ -335,7 +324,6 @@ tigris whoami
 ```
 
 **Examples:**
-
 ```bash
 tigris whoami
 ```
@@ -348,14 +336,13 @@ Save access-key credentials to ~/.tigris/config.json for persistent use across a
 tigris configure [flags]
 ```
 
-| Flag                       | Description                                           |
-| -------------------------- | ----------------------------------------------------- |
-| `-key, --access-key`       | Your Tigris access key ID                             |
-| `-secret, --access-secret` | Your Tigris secret access key                         |
-| `-e, --endpoint`           | Tigris API endpoint (default: https://t3.storage.dev) |
+| Flag | Description |
+|------|-------------|
+| `-key, --access-key` | Your Tigris access key ID |
+| `-secret, --access-secret` | Your Tigris secret access key |
+| `-e, --endpoint` | Tigris API endpoint (default: https://t3.storage.dev) |
 
 **Examples:**
-
 ```bash
 tigris configure --access-key tid_AaBb --access-secret tsec_XxYy
 tigris configure --endpoint https://custom.endpoint.dev
@@ -367,11 +354,11 @@ tigris configure --endpoint https://custom.endpoint.dev
 
 List, create, and switch between organizations. An organization is a workspace that contains your resources like buckets and access keys
 
-| Command                    | Description                                                                 |
-| -------------------------- | --------------------------------------------------------------------------- |
-| `organizations list` (l)   | List all organizations you belong to and interactively select one as active |
-| `organizations create` (c) | Create a new organization with the given name                               |
-| `organizations select` (s) | Set the named organization as your active org for all subsequent commands   |
+| Command | Description |
+|---------|-------------|
+| `organizations list` (l) | List all organizations you belong to and interactively select one as active |
+| `organizations create` (c) | Create a new organization with the given name |
+| `organizations select` (s) | Set the named organization as your active org for all subsequent commands |
 
 #### `organizations list`
 
@@ -379,13 +366,12 @@ List, create, and switch between organizations. An organization is a workspace t
 tigris organizations list [flags]
 ```
 
-| Flag           | Description                     |
-| -------------- | ------------------------------- |
-| `--format`     | Output format (default: select) |
-| `-i, --select` | Interactive selection mode      |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: select) |
+| `-i, --select` | Interactive selection mode |
 
 **Examples:**
-
 ```bash
 tigris orgs list
 tigris orgs list --format json
@@ -398,7 +384,6 @@ tigris organizations create <name>
 ```
 
 **Examples:**
-
 ```bash
 tigris orgs create my-org
 ```
@@ -410,7 +395,6 @@ tigris organizations select <name>
 ```
 
 **Examples:**
-
 ```bash
 tigris orgs select my-org
 ```
@@ -419,17 +403,17 @@ tigris orgs select my-org
 
 Create, list, inspect, delete, and assign roles to access keys. Access keys are credentials used for programmatic API access
 
-| Command                          | Description                                                                                                                         |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `access-keys list` (l)           | List all access keys in the current organization                                                                                    |
-| `access-keys create` (c)         | Create a new access key with the given name. Returns the key ID and secret (shown only once)                                        |
-| `access-keys delete` (d)         | Permanently delete an access key by its ID. This revokes all access immediately                                                     |
-| `access-keys get` (g)            | Show details for an access key including its name, creation date, and assigned bucket roles                                         |
-| `access-keys assign` (a)         | Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor or ReadOnly), or use --admin for org-wide access |
-| `access-keys rotate` (r)         | Rotate an access key's secret. The current secret is immediately invalidated and a new one is returned (shown only once)            |
-| `access-keys attach-policy` (ap) | Attach an IAM policy to an access key. If no policy ARN is provided, shows interactive selection of available policies              |
-| `access-keys detach-policy` (dp) | Detach an IAM policy from an access key. If no policy ARN is provided, shows interactive selection of attached policies             |
-| `access-keys list-policies` (lp) | List all IAM policies attached to an access key                                                                                     |
+| Command | Description |
+|---------|-------------|
+| `access-keys list` (l) | List all access keys in the current organization |
+| `access-keys create` (c) | Create a new access key with the given name. Returns the key ID and secret (shown only once) |
+| `access-keys delete` (d) | Permanently delete an access key by its ID. This revokes all access immediately |
+| `access-keys get` (g) | Show details for an access key including its name, creation date, and assigned bucket roles |
+| `access-keys assign` (a) | Assign per-bucket roles to an access key. Pair each --bucket with a --role (Editor or ReadOnly), or use --admin for org-wide access |
+| `access-keys rotate` (r) | Rotate an access key's secret. The current secret is immediately invalidated and a new one is returned (shown only once) |
+| `access-keys attach-policy` (ap) | Attach an IAM policy to an access key. If no policy ARN is provided, shows interactive selection of available policies |
+| `access-keys detach-policy` (dp) | Detach an IAM policy from an access key. If no policy ARN is provided, shows interactive selection of attached policies |
+| `access-keys list-policies` (lp) | List all IAM policies attached to an access key |
 
 #### `access-keys list`
 
@@ -437,14 +421,13 @@ Create, list, inspect, delete, and assign roles to access keys. Access keys are 
 tigris access-keys list [flags]
 ```
 
-| Flag                | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `--format`          | Output format (default: table)                                  |
-| `--limit`           | Maximum number of items to return per page                      |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: table) |
+| `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 
 **Examples:**
-
 ```bash
 tigris access-keys list
 ```
@@ -456,7 +439,6 @@ tigris access-keys create <name>
 ```
 
 **Examples:**
-
 ```bash
 tigris access-keys create my-ci-key
 ```
@@ -467,12 +449,11 @@ tigris access-keys create my-ci-key
 tigris access-keys delete <id> [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris access-keys delete tid_AaBbCcDdEeFf --yes
 ```
@@ -484,7 +465,6 @@ tigris access-keys get <id>
 ```
 
 **Examples:**
-
 ```bash
 tigris access-keys get tid_AaBbCcDdEeFf
 ```
@@ -495,15 +475,14 @@ tigris access-keys get tid_AaBbCcDdEeFf
 tigris access-keys assign <id> [flags]
 ```
 
-| Flag             | Description                                                                                                   |
-| ---------------- | ------------------------------------------------------------------------------------------------------------- |
-| `-b, --bucket`   | Bucket name (can specify multiple, comma-separated). Each bucket is paired positionally with a --role value   |
-| `-r, --role`     | Role to assign (can specify multiple, comma-separated). Each role pairs with the corresponding --bucket value |
-| `--admin`        | Grant admin access to all buckets in the organization                                                         |
-| `--revoke-roles` | Revoke all bucket roles from the access key                                                                   |
+| Flag | Description |
+|------|-------------|
+| `-b, --bucket` | Bucket name (can specify multiple, comma-separated). Each bucket is paired positionally with a --role value |
+| `-r, --role` | Role to assign (can specify multiple, comma-separated). Each role pairs with the corresponding --bucket value |
+| `--admin` | Grant admin access to all buckets in the organization |
+| `--revoke-roles` | Revoke all bucket roles from the access key |
 
 **Examples:**
-
 ```bash
 tigris access-keys assign tid_AaBb --bucket my-bucket --role Editor
 tigris access-keys assign tid_AaBb --bucket a,b --role Editor,ReadOnly
@@ -517,12 +496,11 @@ tigris access-keys assign tid_AaBb --revoke-roles
 tigris access-keys rotate <id> [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris access-keys rotate tid_AaBbCcDdEeFf --yes
 ```
@@ -533,12 +511,11 @@ tigris access-keys rotate tid_AaBbCcDdEeFf --yes
 tigris access-keys attach-policy <id> [flags]
 ```
 
-| Flag           | Description                 |
-| -------------- | --------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--policy-arn` | ARN of the policy to attach |
 
 **Examples:**
-
 ```bash
 tigris access-keys attach-policy tid_AaBb --policy-arn arn:aws:iam::org_id:policy/my-policy
 tigris access-keys attach-policy tid_AaBb
@@ -550,13 +527,12 @@ tigris access-keys attach-policy tid_AaBb
 tigris access-keys detach-policy <id> [flags]
 ```
 
-| Flag           | Description                                 |
-| -------------- | ------------------------------------------- |
-| `--policy-arn` | ARN of the policy to detach                 |
-| `--force`      | Skip confirmation prompts (alias for --yes) |
+| Flag | Description |
+|------|-------------|
+| `--policy-arn` | ARN of the policy to detach |
+| `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris access-keys detach-policy tid_AaBb --policy-arn arn:aws:iam::org_id:policy/my-policy --yes
 tigris access-keys detach-policy tid_AaBb
@@ -568,14 +544,13 @@ tigris access-keys detach-policy tid_AaBb
 tigris access-keys list-policies <id> [flags]
 ```
 
-| Flag                | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `--format`          | Output format (default: table)                                  |
-| `--limit`           | Maximum number of items to return per page                      |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: table) |
+| `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 
 **Examples:**
-
 ```bash
 tigris access-keys list-policies tid_AaBbCcDdEeFf
 ```
@@ -584,8 +559,8 @@ tigris access-keys list-policies tid_AaBbCcDdEeFf
 
 Test whether your current credentials can reach Tigris and optionally verify access to a specific bucket
 
-| Command                | Description                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
+| Command | Description |
+|---------|-------------|
 | `credentials test` (t) | Verify that current credentials are valid. Optionally checks access to a specific bucket |
 
 #### `credentials test`
@@ -594,12 +569,11 @@ Test whether your current credentials can reach Tigris and optionally verify acc
 tigris credentials test [flags]
 ```
 
-| Flag           | Description                                   |
-| -------------- | --------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-b, --bucket` | Bucket name to test access against (optional) |
 
 **Examples:**
-
 ```bash
 tigris credentials test
 tigris credentials test --bucket my-bucket
@@ -613,19 +587,20 @@ Buckets are containers for objects. You can also create forks and snapshots of b
 
 Create, inspect, update, and delete buckets. Buckets are top-level containers that hold objects
 
-| Command                     | Description                                                                                                                                             |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `buckets list` (l)          | List all buckets in the current organization                                                                                                            |
-| `buckets create` (c)        | Create a new bucket with optional access, tier, and location settings                                                                                   |
-| `buckets get` (g)           | Show details for a bucket including access level, region, tier, and custom domain                                                                       |
-| `buckets delete` (d)        | Delete one or more buckets by name. The bucket must be empty or delete-protection must be off                                                           |
-| `buckets set` (s)           | Update settings on an existing bucket such as access level, location, caching, or custom domain                                                         |
-| `buckets set-ttl`           | Configure object expiration (TTL) on a bucket. Objects expire after a number of days or on a specific date                                              |
-| `buckets set-locations`     | Set the data locations for a bucket                                                                                                                     |
-| `buckets set-migration`     | Configure data migration from an external S3-compatible source bucket. Tigris will pull objects on demand from the source                               |
-| `buckets set-transition`    | Configure a lifecycle transition rule on a bucket. Automatically move objects to a different storage class after a number of days or on a specific date |
-| `buckets set-notifications` | Configure object event notifications on a bucket. Sends webhook requests to a URL when objects are created, updated, or deleted                         |
-| `buckets set-cors`          | Configure CORS rules on a bucket. Each invocation adds a rule unless --override or --reset is used                                                      |
+| Command | Description |
+|---------|-------------|
+| `buckets list` (l) | List all buckets in the current organization |
+| `buckets create` (c) | Create a new bucket with optional access, tier, and location settings |
+| `buckets get` (g) | Show details for a bucket including access level, region, tier, and custom domain |
+| `buckets delete` (d) | Delete one or more buckets by name. The bucket must be empty or delete-protection must be off |
+| `buckets set` (s) | Update settings on an existing bucket such as access level, location, caching, or custom domain |
+| `buckets set-ttl` | Configure object expiration (TTL) on a bucket. Objects expire after a number of days or on a specific date |
+| `buckets set-locations` | Set the data locations for a bucket |
+| `buckets set-migration` | Configure data migration from an external S3-compatible source bucket. Tigris will pull objects on demand from the source |
+| `buckets migrate` | Actively migrate all objects from a shadow bucket to Tigris by scheduling server-side migration for unmigrated objects |
+| `buckets set-transition` | Configure a lifecycle transition rule on a bucket. Automatically move objects to a different storage class after a number of days or on a specific date |
+| `buckets set-notifications` | Configure object event notifications on a bucket. Sends webhook requests to a URL when objects are created, updated, or deleted |
+| `buckets set-cors` | Configure CORS rules on a bucket. Each invocation adds a rule unless --override or --reset is used |
 
 ##### `buckets list`
 
@@ -633,15 +608,14 @@ Create, inspect, update, and delete buckets. Buckets are top-level containers th
 tigris buckets list [flags]
 ```
 
-| Flag                | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `--format`          | Output format (default: table)                                  |
-| `--forks-of`        | Only list buckets that are forks of the named source bucket     |
-| `--limit`           | Maximum number of items to return per page                      |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: table) |
+| `--forks-of` | Only list buckets that are forks of the named source bucket |
+| `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 
 **Examples:**
-
 ```bash
 tigris buckets list
 tigris buckets list --format json
@@ -654,20 +628,19 @@ tigris buckets list --forks-of my-bucket
 tigris buckets create [name] [flags]
 ```
 
-| Flag                              | Description                                                                                                                                                                     |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-a, --access`                    | Access level (default: private)                                                                                                                                                 |
-| `--public`                        | Shorthand for --access public                                                                                                                                                   |
-| `-s, --enable-snapshots`          | Enable snapshots for the bucket (default: false)                                                                                                                                |
-| `-t, --default-tier`              | Choose the default tier for the bucket (default: STANDARD)                                                                                                                      |
-| `-c, --consistency`               | (Deprecated, use --locations) Choose the consistency level for the bucket                                                                                                       |
-| `-r, --region`                    | (Deprecated, use --locations) Region                                                                                                                                            |
-| `-l, --locations`                 | Location for the bucket (default: global)                                                                                                                                       |
-| `-fork, --fork-of`                | Create this bucket as a fork (copy-on-write clone) of the named source bucket                                                                                                   |
+| Flag | Description |
+|------|-------------|
+| `-a, --access` | Access level (default: private) |
+| `--public` | Shorthand for --access public |
+| `-s, --enable-snapshots` | Enable snapshots for the bucket (default: false) |
+| `-t, --default-tier` | Choose the default tier for the bucket (default: STANDARD) |
+| `-c, --consistency` | (Deprecated, use --locations) Choose the consistency level for the bucket |
+| `-r, --region` | (Deprecated, use --locations) Region |
+| `-l, --locations` | Location for the bucket (default: global) |
+| `-fork, --fork-of` | Create this bucket as a fork (copy-on-write clone) of the named source bucket |
 | `-source-snap, --source-snapshot` | Fork from a specific snapshot of the source bucket. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464). Requires --fork-of |
 
 **Examples:**
-
 ```bash
 tigris buckets create my-bucket
 tigris buckets create my-bucket --access public --locations iad
@@ -682,12 +655,11 @@ tigris buckets create my-fork --fork-of my-bucket --source-snapshot 176588900050
 tigris buckets get <name> [flags]
 ```
 
-| Flag       | Description                    |
-| ---------- | ------------------------------ |
+| Flag | Description |
+|------|-------------|
 | `--format` | Output format (default: table) |
 
 **Examples:**
-
 ```bash
 tigris buckets get my-bucket
 ```
@@ -698,12 +670,11 @@ tigris buckets get my-bucket
 tigris buckets delete <name> [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris buckets delete my-bucket --yes
 tigris buckets delete bucket-a,bucket-b --yes
@@ -715,20 +686,19 @@ tigris buckets delete bucket-a,bucket-b --yes
 tigris buckets set <name> [flags]
 ```
 
-| Flag                          | Description                                                                               |
-| ----------------------------- | ----------------------------------------------------------------------------------------- |
-| `--access`                    | Bucket access level                                                                       |
-| `--region`                    | (Deprecated, use --locations) Allowed regions (can specify multiple)                      |
-| `--locations`                 | Bucket location (see https://www.tigrisdata.com/docs/buckets/locations/ for more details) |
-| `--allow-object-acl`          | Enable object-level ACL                                                                   |
-| `--disable-directory-listing` | Disable directory listing                                                                 |
-| `--cache-control`             | Default cache-control header value                                                        |
-| `--custom-domain`             | Custom domain for the bucket                                                              |
-| `--enable-delete-protection`  | Enable delete protection                                                                  |
-| `--enable-additional-headers` | Enable additional HTTP headers (X-Content-Type-Options nosniff)                           |
+| Flag | Description |
+|------|-------------|
+| `--access` | Bucket access level |
+| `--region` | (Deprecated, use --locations) Allowed regions (can specify multiple) |
+| `--locations` | Bucket location (see https://www.tigrisdata.com/docs/buckets/locations/ for more details) |
+| `--allow-object-acl` | Enable object-level ACL |
+| `--disable-directory-listing` | Disable directory listing |
+| `--cache-control` | Default cache-control header value |
+| `--custom-domain` | Custom domain for the bucket |
+| `--enable-delete-protection` | Enable delete protection |
+| `--enable-additional-headers` | Enable additional HTTP headers (X-Content-Type-Options nosniff) |
 
 **Examples:**
-
 ```bash
 tigris buckets set my-bucket --access public
 tigris buckets set my-bucket --locations iad,fra --cache-control 'max-age=3600'
@@ -741,15 +711,14 @@ tigris buckets set my-bucket --custom-domain assets.example.com
 tigris buckets set-ttl <name> [flags]
 ```
 
-| Flag         | Description                                              |
-| ------------ | -------------------------------------------------------- |
-| `-d, --days` | Expire objects after this many days                      |
-| `--date`     | Expire objects on this date (ISO-8601, e.g. 2026-06-01)  |
-| `--enable`   | Enable TTL on the bucket (uses existing lifecycle rules) |
-| `--disable`  | Disable TTL on the bucket                                |
+| Flag | Description |
+|------|-------------|
+| `-d, --days` | Expire objects after this many days |
+| `--date` | Expire objects on this date (ISO-8601, e.g. 2026-06-01) |
+| `--enable` | Enable TTL on the bucket (uses existing lifecycle rules) |
+| `--disable` | Disable TTL on the bucket |
 
 **Examples:**
-
 ```bash
 tigris buckets set-ttl my-bucket --days 30
 tigris buckets set-ttl my-bucket --date 2026-06-01
@@ -762,12 +731,11 @@ tigris buckets set-ttl my-bucket --disable
 tigris buckets set-locations <name> [flags]
 ```
 
-| Flag              | Description     |
-| ----------------- | --------------- |
+| Flag | Description |
+|------|-------------|
 | `-l, --locations` | Bucket location |
 
 **Examples:**
-
 ```bash
 tigris buckets set-locations my-bucket --locations iad
 tigris buckets set-locations my-bucket --locations iad,fra
@@ -780,22 +748,34 @@ tigris buckets set-locations my-bucket --locations global
 tigris buckets set-migration <name> [flags]
 ```
 
-| Flag                    | Description                                                     |
-| ----------------------- | --------------------------------------------------------------- |
-| `-b, --bucket`          | Name of the source bucket to migrate from                       |
-| `-e, --endpoint`        | Endpoint URL of the source S3-compatible service                |
-| `-r, --region`          | Region of the source bucket                                     |
-| `-key, --access-key`    | Access key for the source bucket                                |
-| `-secret, --secret-key` | Secret key for the source bucket                                |
-| `--write-through`       | Enable write-through mode (writes go to both source and Tigris) |
-| `--disable`             | Disable migration and clear all migration settings              |
+| Flag | Description |
+|------|-------------|
+| `-b, --bucket` | Name of the source bucket to migrate from |
+| `-e, --endpoint` | Endpoint URL of the source S3-compatible service |
+| `-r, --region` | Region of the source bucket |
+| `-key, --access-key` | Access key for the source bucket |
+| `-secret, --secret-key` | Secret key for the source bucket |
+| `--write-through` | Enable write-through mode (writes go to both source and Tigris) |
+| `--disable` | Disable migration and clear all migration settings |
 
 **Examples:**
-
 ```bash
 tigris buckets set-migration my-bucket --bucket source-bucket --endpoint https://s3.amazonaws.com --region us-east-1 --access-key AKIA... --secret-key wJal...
 tigris buckets set-migration my-bucket --bucket source-bucket --endpoint https://s3.amazonaws.com --region us-east-1 --access-key AKIA... --secret-key wJal... --write-through
 tigris buckets set-migration my-bucket --disable
+```
+
+##### `buckets migrate`
+
+```
+tigris buckets migrate <path>
+```
+
+**Examples:**
+```bash
+tigris buckets migrate my-bucket
+tigris buckets migrate my-bucket/images/
+tigris buckets migrate t3://my-bucket/prefix/
 ```
 
 ##### `buckets set-transition`
@@ -804,16 +784,15 @@ tigris buckets set-migration my-bucket --disable
 tigris buckets set-transition <name> [flags]
 ```
 
-| Flag                  | Description                                                 |
-| --------------------- | ----------------------------------------------------------- |
-| `-s, --storage-class` | Target storage class to transition objects to               |
-| `-d, --days`          | Transition objects after this many days                     |
-| `--date`              | Transition objects on this date (ISO-8601, e.g. 2026-06-01) |
-| `--enable`            | Enable lifecycle transition rules on the bucket             |
-| `--disable`           | Disable lifecycle transition rules on the bucket            |
+| Flag | Description |
+|------|-------------|
+| `-s, --storage-class` | Target storage class to transition objects to |
+| `-d, --days` | Transition objects after this many days |
+| `--date` | Transition objects on this date (ISO-8601, e.g. 2026-06-01) |
+| `--enable` | Enable lifecycle transition rules on the bucket |
+| `--disable` | Disable lifecycle transition rules on the bucket |
 
 **Examples:**
-
 ```bash
 tigris buckets set-transition my-bucket --storage-class STANDARD_IA --days 30
 tigris buckets set-transition my-bucket --storage-class GLACIER --date 2026-06-01
@@ -827,19 +806,18 @@ tigris buckets set-transition my-bucket --disable
 tigris buckets set-notifications <name> [flags]
 ```
 
-| Flag           | Description                                                                  |
-| -------------- | ---------------------------------------------------------------------------- |
-| `-u, --url`    | Webhook URL to send notifications to (must be http or https)                 |
+| Flag | Description |
+|------|-------------|
+| `-u, --url` | Webhook URL to send notifications to (must be http or https) |
 | `-f, --filter` | SQL WHERE clause to filter events by key (e.g. WHERE `key` REGEXP "^images") |
-| `-t, --token`  | Token for webhook authentication                                             |
-| `--username`   | Username for basic webhook authentication                                    |
-| `--password`   | Password for basic webhook authentication                                    |
-| `--enable`     | Enable notifications on the bucket (uses existing config)                    |
-| `--disable`    | Disable notifications on the bucket (preserves existing config)              |
-| `--reset`      | Clear all notification settings on the bucket                                |
+| `-t, --token` | Token for webhook authentication |
+| `--username` | Username for basic webhook authentication |
+| `--password` | Password for basic webhook authentication |
+| `--enable` | Enable notifications on the bucket (uses existing config) |
+| `--disable` | Disable notifications on the bucket (preserves existing config) |
+| `--reset` | Clear all notification settings on the bucket |
 
 **Examples:**
-
 ```bash
 tigris buckets set-notifications my-bucket --url https://example.com/webhook
 tigris buckets set-notifications my-bucket --url https://example.com/webhook --token secret123
@@ -856,18 +834,17 @@ tigris buckets set-notifications my-bucket --reset
 tigris buckets set-cors <name> [flags]
 ```
 
-| Flag               | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| `-o, --origins`    | Allowed origins (comma-separated, or '\*' for all)         |
-| `-m, --methods`    | Allowed HTTP methods (comma-separated, e.g. GET,POST,PUT)  |
-| `--headers`        | Allowed request headers (comma-separated, or '\*' for all) |
-| `--expose-headers` | Response headers to expose (comma-separated)               |
-| `--max-age`        | Preflight cache duration in seconds (default: 3600)        |
-| `--override`       | Replace all existing CORS rules instead of appending       |
-| `--reset`          | Clear all CORS rules on the bucket                         |
+| Flag | Description |
+|------|-------------|
+| `-o, --origins` | Allowed origins (comma-separated, or '*' for all) |
+| `-m, --methods` | Allowed HTTP methods (comma-separated, e.g. GET,POST,PUT) |
+| `--headers` | Allowed request headers (comma-separated, or '*' for all) |
+| `--expose-headers` | Response headers to expose (comma-separated) |
+| `--max-age` | Preflight cache duration in seconds (default: 3600) |
+| `--override` | Replace all existing CORS rules instead of appending |
+| `--reset` | Clear all CORS rules on the bucket |
 
 **Examples:**
-
 ```bash
 tigris buckets set-cors my-bucket --origins '*' --methods GET,HEAD
 tigris buckets set-cors my-bucket --origins https://example.com --methods GET,POST --headers Content-Type,Authorization --max-age 3600
@@ -879,9 +856,9 @@ tigris buckets set-cors my-bucket --reset
 
 (Deprecated, use "buckets create --fork-of" and "buckets list --forks-of") List and create forks
 
-| Command            | Description                                                                                               |
-| ------------------ | --------------------------------------------------------------------------------------------------------- |
-| `forks list` (l)   | (Deprecated, use "buckets list --forks-of") List all forks created from the given source bucket           |
+| Command | Description |
+|---------|-------------|
+| `forks list` (l) | (Deprecated, use "buckets list --forks-of") List all forks created from the given source bucket |
 | `forks create` (c) | (Deprecated, use "buckets create --fork-of") Create a new fork (copy-on-write clone) of the source bucket |
 
 ##### `forks list`
@@ -890,12 +867,11 @@ tigris buckets set-cors my-bucket --reset
 tigris forks list <name> [flags]
 ```
 
-| Flag       | Description                    |
-| ---------- | ------------------------------ |
+| Flag | Description |
+|------|-------------|
 | `--format` | Output format (default: table) |
 
 **Examples:**
-
 ```bash
 tigris forks list my-bucket
 tigris forks list my-bucket --format json
@@ -907,12 +883,11 @@ tigris forks list my-bucket --format json
 tigris forks create <name> <fork-name> [flags]
 ```
 
-| Flag             | Description                                                                                                                                   |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-s, --snapshot` | Create fork from a specific snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
 
 **Examples:**
-
 ```bash
 tigris forks create my-bucket my-fork
 tigris forks create my-bucket my-fork --snapshot 1765889000501544464
@@ -922,9 +897,9 @@ tigris forks create my-bucket my-fork --snapshot 1765889000501544464
 
 List and take snapshots. A snapshot is a point-in-time, read-only copy of a bucket's state
 
-| Command              | Description                                                                                   |
-| -------------------- | --------------------------------------------------------------------------------------------- |
-| `snapshots list` (l) | List all snapshots for the given bucket, ordered by creation time                             |
+| Command | Description |
+|---------|-------------|
+| `snapshots list` (l) | List all snapshots for the given bucket, ordered by creation time |
 | `snapshots take` (t) | Take a new snapshot of the bucket's current state. Optionally provide a name for the snapshot |
 
 ##### `snapshots list`
@@ -933,14 +908,13 @@ List and take snapshots. A snapshot is a point-in-time, read-only copy of a buck
 tigris snapshots list <name> [flags]
 ```
 
-| Flag                | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `--format`          | Output format (default: table)                                  |
-| `--limit`           | Maximum number of items to return per page                      |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: table) |
+| `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 
 **Examples:**
-
 ```bash
 tigris snapshots list my-bucket
 tigris snapshots list my-bucket --format json
@@ -953,7 +927,6 @@ tigris snapshots take <name> [snapshot-name]
 ```
 
 **Examples:**
-
 ```bash
 tigris snapshots take my-bucket
 tigris snapshots take my-bucket my-snapshot
@@ -963,14 +936,14 @@ tigris snapshots take my-bucket my-snapshot
 
 Low-level object operations for listing, downloading, uploading, and deleting individual objects in a bucket
 
-| Command              | Description                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------------ |
-| `objects list` (l)   | List objects in a bucket, optionally filtered by a key prefix                                    |
-| `objects get` (g)    | Download an object by key. Prints to stdout by default, or saves to a file with --output         |
-| `objects put` (p)    | Upload a local file as an object. Content-type is auto-detected from extension unless overridden |
-| `objects delete` (d) | Delete one or more objects by key from the given bucket                                          |
-| `objects set` (s)    | Update settings on an existing object such as access level                                       |
-| `objects info` (i)   | Show metadata for an object (content type, size, modified date)                                  |
+| Command | Description |
+|---------|-------------|
+| `objects list` (l) | List objects in a bucket, optionally filtered by a key prefix |
+| `objects get` (g) | Download an object by key. Prints to stdout by default, or saves to a file with --output |
+| `objects put` (p) | Upload a local file as an object. Content-type is auto-detected from extension unless overridden |
+| `objects delete` (d) | Delete one or more objects by key from the given bucket |
+| `objects set` (s) | Update settings on an existing object such as access level |
+| `objects info` (i) | Show metadata for an object (content type, size, modified date) |
 
 #### `objects list`
 
@@ -978,16 +951,16 @@ Low-level object operations for listing, downloading, uploading, and deleting in
 tigris objects list <bucket> [flags]
 ```
 
-| Flag                            | Description                                                                                                                                   |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-p, --prefix`                  | Filter objects by key prefix (e.g. "images/" to list only images)                                                                             |
-| `--format`                      | Output format (default: table)                                                                                                                |
+| Flag | Description |
+|------|-------------|
+| `-p, --prefix` | Filter objects by key prefix (e.g. "images/" to list only images) |
+| `--format` | Output format (default: table) |
 | `-snapshot, --snapshot-version` | Read from a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
-| `--limit`                       | Maximum number of items to return per page                                                                                                    |
-| `-pt, --page-token`             | Pagination token from a previous request to fetch the next page                                                                               |
+| `--limit` | Maximum number of items to return per page |
+| `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
+| `--source` | List objects from a specific storage source on buckets with shadow migration enabled |
 
 **Examples:**
-
 ```bash
 tigris objects list my-bucket
 tigris objects list t3://my-bucket
@@ -1002,14 +975,13 @@ tigris objects list my-bucket --format json
 tigris objects get <bucket> [key] [flags]
 ```
 
-| Flag                            | Description                                                                                                                                   |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-o, --output`                  | Output file path (if not specified, prints to stdout)                                                                                         |
-| `-m, --mode`                    | Response mode: "string" loads into memory, "stream" writes in chunks (auto-detected from extension if not specified)                          |
+| Flag | Description |
+|------|-------------|
+| `-o, --output` | Output file path (if not specified, prints to stdout) |
+| `-m, --mode` | Response mode: "string" loads into memory, "stream" writes in chunks (auto-detected from extension if not specified) |
 | `-snapshot, --snapshot-version` | Read from a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464) |
 
 **Examples:**
-
 ```bash
 tigris objects get my-bucket config.json
 tigris objects get t3://my-bucket/config.json
@@ -1022,14 +994,13 @@ tigris objects get my-bucket archive.zip --output ./archive.zip --mode stream
 tigris objects put <bucket> [key] [file] [flags]
 ```
 
-| Flag                 | Description                                            |
-| -------------------- | ------------------------------------------------------ |
-| `-a, --access`       | Access level (default: private)                        |
+| Flag | Description |
+|------|-------------|
+| `-a, --access` | Access level (default: private) |
 | `-t, --content-type` | Content type (auto-detected from extension if omitted) |
-| `--format`           | Output format (default: table)                         |
+| `--format` | Output format (default: table) |
 
 **Examples:**
-
 ```bash
 tigris objects put my-bucket report.pdf ./report.pdf
 tigris objects put t3://my-bucket/report.pdf ./report.pdf
@@ -1042,12 +1013,11 @@ tigris objects put my-bucket logo.png ./logo.png --access public --content-type 
 tigris objects delete <bucket> [key] [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris objects delete my-bucket old-file.txt --yes
 tigris objects delete t3://my-bucket/old-file.txt --yes
@@ -1060,13 +1030,12 @@ tigris objects delete my-bucket file-a.txt,file-b.txt --yes
 tigris objects set <bucket> [key] [flags]
 ```
 
-| Flag            | Description                    |
-| --------------- | ------------------------------ |
-| `-a, --access`  | Access level                   |
+| Flag | Description |
+|------|-------------|
+| `-a, --access` | Access level |
 | `-n, --new-key` | Rename the object to a new key |
 
 **Examples:**
-
 ```bash
 tigris objects set my-bucket my-file.txt --access public
 tigris objects set t3://my-bucket/my-file.txt --access public
@@ -1079,13 +1048,12 @@ tigris objects set my-bucket my-file.txt --access private
 tigris objects info <bucket> [key] [flags]
 ```
 
-| Flag                            | Description                          |
-| ------------------------------- | ------------------------------------ |
-| `--format`                      | Output format (default: table)       |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: table) |
 | `-snapshot, --snapshot-version` | Read from a specific bucket snapshot |
 
 **Examples:**
-
 ```bash
 tigris objects info my-bucket report.pdf
 tigris objects info t3://my-bucket/report.pdf
@@ -1096,25 +1064,25 @@ tigris objects info my-bucket report.pdf --format json
 
 Identity and Access Management - manage policies, users, and permissions
 
-| Command            | Description                                                      |
-| ------------------ | ---------------------------------------------------------------- |
+| Command | Description |
+|---------|-------------|
 | `iam policies` (p) | Manage IAM policies. Policies define permissions for access keys |
-| `iam users` (u)    | Manage organization users and invitations                        |
+| `iam users` (u) | Manage organization users and invitations |
 
 #### `iam policies` | `p`
 
 Manage IAM policies. Policies define permissions for access keys
 
-| Command                          | Description                                                                                                                                                                |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `iam policies list` (l)          | List all policies in the current organization                                                                                                                              |
-| `iam policies get` (g)           | Show details for a policy including its document and attached users. If no ARN provided, shows interactive selection                                                       |
-| `iam policies create` (c)        | Create a new policy with the given name and policy document. Document can be provided via file, inline JSON, or stdin                                                      |
-| `iam policies edit` (e)          | Update an existing policy's document. Document can be provided via file, inline JSON, or stdin. If no ARN provided, shows interactive selection                            |
-| `iam policies delete` (d)        | Delete a policy. If no ARN provided, shows interactive selection                                                                                                           |
-| `iam policies link-key` (lnk)    | Link an access key to a policy. If no policy ARN is provided, shows interactive selection. If no access key ID is provided, shows interactive selection of unlinked keys   |
+| Command | Description |
+|---------|-------------|
+| `iam policies list` (l) | List all policies in the current organization |
+| `iam policies get` (g) | Show details for a policy including its document and attached users. If no ARN provided, shows interactive selection |
+| `iam policies create` (c) | Create a new policy with the given name and policy document. Document can be provided via file, inline JSON, or stdin |
+| `iam policies edit` (e) | Update an existing policy's document. Document can be provided via file, inline JSON, or stdin. If no ARN provided, shows interactive selection |
+| `iam policies delete` (d) | Delete a policy. If no ARN provided, shows interactive selection |
+| `iam policies link-key` (lnk) | Link an access key to a policy. If no policy ARN is provided, shows interactive selection. If no access key ID is provided, shows interactive selection of unlinked keys |
 | `iam policies unlink-key` (ulnk) | Unlink an access key from a policy. If no policy ARN is provided, shows interactive selection. If no access key ID is provided, shows interactive selection of linked keys |
-| `iam policies list-keys` (lk)    | List all access keys attached to a policy. If no policy ARN is provided, shows interactive selection                                                                       |
+| `iam policies list-keys` (lk) | List all access keys attached to a policy. If no policy ARN is provided, shows interactive selection |
 
 ##### `iam policies list`
 
@@ -1122,14 +1090,13 @@ Manage IAM policies. Policies define permissions for access keys
 tigris iam policies list [flags]
 ```
 
-| Flag                | Description                                                     |
-| ------------------- | --------------------------------------------------------------- |
-| `--format`          | Output format (default: table)                                  |
-| `--limit`           | Maximum number of items to return per page                      |
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: table) |
+| `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 
 **Examples:**
-
 ```bash
 tigris iam policies list
 ```
@@ -1140,12 +1107,11 @@ tigris iam policies list
 tigris iam policies get [resource] [flags]
 ```
 
-| Flag       | Description                    |
-| ---------- | ------------------------------ |
+| Flag | Description |
+|------|-------------|
 | `--format` | Output format (default: table) |
 
 **Examples:**
-
 ```bash
 tigris iam policies get
 tigris iam policies get arn:aws:iam::org_id:policy/my-policy
@@ -1157,13 +1123,12 @@ tigris iam policies get arn:aws:iam::org_id:policy/my-policy
 tigris iam policies create <name> [flags]
 ```
 
-| Flag             | Description                                                                   |
-| ---------------- | ----------------------------------------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-d, --document` | Policy document (JSON file path or inline JSON). If omitted, reads from stdin |
-| `--description`  | Policy description                                                            |
+| `--description` | Policy description |
 
 **Examples:**
-
 ```bash
 tigris iam policies create my-policy --document policy.json
 tigris iam policies create my-policy --document '{"Version":"2012-10-17","Statement":[...]}'
@@ -1176,13 +1141,12 @@ cat policy.json | tigris iam policies create my-policy
 tigris iam policies edit [resource] [flags]
 ```
 
-| Flag             | Description                                                                       |
-| ---------------- | --------------------------------------------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-d, --document` | New policy document (JSON file path or inline JSON). If omitted, reads from stdin |
-| `--description`  | Update policy description                                                         |
+| `--description` | Update policy description |
 
 **Examples:**
-
 ```bash
 tigris iam policies edit --document policy.json
 tigris iam policies edit arn:aws:iam::org_id:policy/my-policy --document policy.json
@@ -1195,12 +1159,11 @@ cat policy.json | tigris iam policies edit arn:aws:iam::org_id:policy/my-policy
 tigris iam policies delete [resource] [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris iam policies delete
 tigris iam policies delete arn:aws:iam::org_id:policy/my-policy --yes
@@ -1212,12 +1175,11 @@ tigris iam policies delete arn:aws:iam::org_id:policy/my-policy --yes
 tigris iam policies link-key [resource] [flags]
 ```
 
-| Flag   | Description             |
-| ------ | ----------------------- |
+| Flag | Description |
+|------|-------------|
 | `--id` | Access key ID to attach |
 
 **Examples:**
-
 ```bash
 tigris iam policies link-key arn:aws:iam::org_id:policy/my-policy --id tid_AaBb
 tigris iam policies link-key
@@ -1229,13 +1191,12 @@ tigris iam policies link-key
 tigris iam policies unlink-key [resource] [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
-| `--id`    | Access key ID to detach                     |
+| Flag | Description |
+|------|-------------|
+| `--id` | Access key ID to detach |
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris iam policies unlink-key arn:aws:iam::org_id:policy/my-policy --id tid_AaBb --yes
 tigris iam policies unlink-key
@@ -1247,12 +1208,11 @@ tigris iam policies unlink-key
 tigris iam policies list-keys [resource] [flags]
 ```
 
-| Flag       | Description                    |
-| ---------- | ------------------------------ |
+| Flag | Description |
+|------|-------------|
 | `--format` | Output format (default: table) |
 
 **Examples:**
-
 ```bash
 tigris iam policies list-keys arn:aws:iam::org_id:policy/my-policy
 tigris iam policies list-keys
@@ -1262,13 +1222,13 @@ tigris iam policies list-keys
 
 Manage organization users and invitations
 
-| Command                            | Description                                                                                |
-| ---------------------------------- | ------------------------------------------------------------------------------------------ |
-| `iam users list` (l)               | List all users and pending invitations in the organization                                 |
-| `iam users invite` (i)             | Invite users to the organization by email                                                  |
-| `iam users revoke-invitation` (ri) | Revoke pending invitations. If no invitation ID provided, shows interactive selection      |
-| `iam users update-role` (ur)       | Update user roles in the organization. If no user ID provided, shows interactive selection |
-| `iam users remove` (rm)            | Remove users from the organization. If no user ID provided, shows interactive selection    |
+| Command | Description |
+|---------|-------------|
+| `iam users list` (l) | List all users and pending invitations in the organization |
+| `iam users invite` (i) | Invite users to the organization by email |
+| `iam users revoke-invitation` (ri) | Revoke pending invitations. If no invitation ID provided, shows interactive selection |
+| `iam users update-role` (ur) | Update user roles in the organization. If no user ID provided, shows interactive selection |
+| `iam users remove` (rm) | Remove users from the organization. If no user ID provided, shows interactive selection |
 
 ##### `iam users list`
 
@@ -1276,12 +1236,11 @@ Manage organization users and invitations
 tigris iam users list [flags]
 ```
 
-| Flag       | Description                    |
-| ---------- | ------------------------------ |
+| Flag | Description |
+|------|-------------|
 | `--format` | Output format (default: table) |
 
 **Examples:**
-
 ```bash
 tigris iam users list
 tigris iam users list --format json
@@ -1293,12 +1252,11 @@ tigris iam users list --format json
 tigris iam users invite <email> [flags]
 ```
 
-| Flag         | Description                                             |
-| ------------ | ------------------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-r, --role` | Role to assign to the invited user(s) (default: member) |
 
 **Examples:**
-
 ```bash
 tigris iam users invite user@example.com
 tigris iam users invite user@example.com --role admin
@@ -1311,12 +1269,11 @@ tigris iam users invite user1@example.com,user2@example.com
 tigris iam users revoke-invitation [resource] [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris iam users revoke-invitation
 tigris iam users revoke-invitation invitation_id --yes
@@ -1329,12 +1286,11 @@ tigris iam users revoke-invitation id1,id2,id3 --yes
 tigris iam users update-role [resource] [flags]
 ```
 
-| Flag         | Description                                                                                                                        |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `-r, --role` | Role(s) to assign (comma-separated). Each role pairs with the corresponding user ID. If one role is given, it applies to all users |
 
 **Examples:**
-
 ```bash
 tigris iam users update-role --role admin
 tigris iam users update-role user_id --role member
@@ -1348,12 +1304,11 @@ tigris iam users update-role id1,id2 --role admin,member
 tigris iam users remove [resource] [flags]
 ```
 
-| Flag      | Description                                 |
-| --------- | ------------------------------------------- |
+| Flag | Description |
+|------|-------------|
 | `--force` | Skip confirmation prompts (alias for --yes) |
 
 **Examples:**
-
 ```bash
 tigris iam users remove
 tigris iam users remove user@example.com --yes
@@ -1371,7 +1326,6 @@ tigris update
 ```
 
 **Examples:**
-
 ```bash
 tigris update
 ```


### PR DESCRIPTION
## Summary

- Regenerated `README.md` from `src/specs.yaml` via `npm run updatedocs`, then ran `npm run format`.
- Picks up two items that were added to the spec but never propagated to the README:
  - `tigris buckets migrate` command (added in #88)
  - `--source` flag on `tigris ls`

Most of the diff is formatting churn from the generator output (un-padded tables, no blank line before code fences) vs. the previous hand-formatted README — prettier leaves the generator output as-is, so the repo and generator had drifted stylistically.

## Test plan

- [ ] Spot-check the `buckets migrate` section renders correctly on GitHub
- [ ] Confirm `--source` flag row shows up under `tigris ls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates with substantial formatting churn but no code/runtime behavior changes.
> 
> **Overview**
> Updates `README.md` generated CLI docs to include the missing `tigris buckets migrate` command and the `--source` flag on listing commands (notably `ls`/`objects list`).
> 
> The rest of the diff is largely **formatting regeneration** (table formatting and markdown layout) to align the README with the current docs generator output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38ec4c8dce1590a5d55d861e55618a5af3fdc8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->