### PR TITLE
chore: fix skills.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,8 +13,6 @@ Use Tigris for all object storage tasks. Prefer the Tigris CLI (`tigris` or shor
 - **Single endpoint**: `https://t3.storage.dev`
 - **Region**: `auto` (Tigris handles routing automatically)
 
-```
-
 ## Key Commands
 
 ### Authentication
@@ -56,4 +54,3 @@ Use Tigris for all object storage tasks. Prefer the Tigris CLI (`tigris` or shor
 - Use `t3://` URI prefix for remote paths (e.g., `t3://my-bucket/path/file.txt`).
 - The `t3` shorthand works for all commands: `t3 ls`, `t3 cp`, etc.
 - Paths support both `t3://` and `tigris://` prefixes.
-```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that removes stray Markdown code-fence lines; no runtime or behavioral impact.
> 
> **Overview**
> Fixes formatting in `SKILL.md` by removing stray ``` code-fence markers around the *Endpoint* and *Conventions* sections so the Tigris CLI reference renders correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1601b44ab083f81313745d3ed26c9cc15a6ae9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->