### PR TITLE
fix!: switch semantic-release to conventionalcommits preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^10.0.1",
         "@types/node": "^22.19.11",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "dotenv": "^17.4.2",
         "eslint": "^10.2.1",
         "eslint-plugin-simple-import-sort": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
       [
         "@semantic-release/commit-analyzer",
         {
+          "preset": "conventionalcommits",
           "releaseRules": [
             {
               "type": "refactor",
@@ -84,7 +85,12 @@
           ]
         }
       ],
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
       "@semantic-release/github",
       "@semantic-release/npm"
     ]
@@ -105,6 +111,7 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.19.11",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "dotenv": "^17.4.2",
     "eslint": "^10.2.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
           "preset": "conventionalcommits",
           "releaseRules": [
             {
+              "breaking": true,
+              "release": "major"
+            },
+            {
               "type": "refactor",
               "release": "patch"
             }


### PR DESCRIPTION
## Summary
- Default `angular` preset doesn't recognise the `!` syntax for breaking changes, so the `feat!:` commit from #95 was classified as "no release" and tagged `v2.18.1-beta.1` instead of `v3.0.0-beta.1`.
- Switch both `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` to the `conventionalcommits` preset.
- Add `conventional-changelog-conventionalcommits ^9.3.1` as a dev dependency so semantic-release can load the preset.

## Why this commit triggers a major bump

This commit uses `fix!:` and includes two `BREAKING CHANGE:` footers documenting the breakage that was supposed to be released as `3.0.0` from #95 but was missed by the release tooling. Because main now contains the new preset config when the next release run executes, semantic-release will re-analyse this commit (and earlier post-release commits) and produce a major version. Combined with the `prerelease: beta` setting, the next release tag should be `v3.0.0-beta.1` (or `.beta.2` if the runner increments past the existing `2.18.1-beta.1`).

## Test plan
- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm test` passes (647 unit tests)
- [x] Verified locally that the `conventionalcommits` preset's parser recognises `feat!:` and emits a `BREAKING CHANGE` note (without it, `type` is detected but the note is missing)
- [ ] Re-run the Release workflow on `main` after merge and confirm the next tag is `v3.0.0-beta.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes release tooling configuration and adds a dev dependency, with no runtime code impact. Main risk is unintended versioning/release-note changes if commit parsing differs from prior behavior.
> 
> **Overview**
> Updates `semantic-release` configuration to use the `conventionalcommits` preset for both `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator`, including an explicit rule to treat detected breaking changes as a **major** release.
> 
> Adds `conventional-changelog-conventionalcommits` as a dev dependency (and lockfile update) so the preset can be resolved during release runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029f49da8dd4dd319ec5ab387ad784d4c7d04c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->