### PR TITLE
fix: auto-detect Content-Type on upload to match aws s3 cp

### DIFF
--- a/src/lib/cp.ts
+++ b/src/lib/cp.ts
@@ -3,6 +3,7 @@ import { get, head, list, put } from '@tigrisdata/storage';
 import { executeWithConcurrency } from '@utils/concurrency.js';
 import { exitWithError } from '@utils/exit.js';
 import { formatSize } from '@utils/format.js';
+import { getContentType } from '@utils/mime.js';
 import { getFormat, getOption } from '@utils/options.js';
 import {
   globToRegex,
@@ -113,8 +114,11 @@ async function uploadFile(
   const fileStream = createReadStream(localPath);
   const body = Readable.toWeb(fileStream) as ReadableStream;
 
+  const contentType = getContentType(localPath);
+
   const { error: putError } = await put(key, body, {
     ...calculateUploadParams(fileSize),
+    ...(contentType ? { contentType } : {}),
     onUploadProgress: showProgress
       ? ({ loaded }) => {
           if (fileSize !== undefined && fileSize > 0) {
@@ -224,16 +228,17 @@ async function copyObject(
     return {};
   }
 
-  let fileSize: number | undefined;
-  if (showProgress) {
-    const { data: headData } = await head(srcKey, {
-      config: {
-        ...config,
-        bucket: srcBucket,
-      },
-    });
-    fileSize = headData?.size;
-  }
+  // head() is unconditional now: we need the source's Content-Type
+  // to propagate it to the destination so a remote→remote copy
+  // doesn't strip the header.
+  const { data: headData } = await head(srcKey, {
+    config: {
+      ...config,
+      bucket: srcBucket,
+    },
+  });
+  const fileSize = headData?.size;
+  const sourceContentType = headData?.contentType;
 
   const { data, error: getError } = await get(srcKey, 'stream', {
     config: {
@@ -248,6 +253,7 @@ async function copyObject(
 
   const { error: putError } = await put(destKey, data, {
     ...calculateUploadParams(fileSize),
+    ...(sourceContentType ? { contentType: sourceContentType } : {}),
     onUploadProgress: showProgress
       ? ({ loaded }) => {
           if (fileSize !== undefined && fileSize > 0) {

--- a/src/lib/mv.ts
+++ b/src/lib/mv.ts
@@ -342,7 +342,9 @@ async function moveObject(
     return {};
   }
 
-  // Get source object size for upload params and progress
+  // Get source object size and content-type for upload params and
+  // header propagation. Without this, a remote→remote move would
+  // strip the source's Content-Type.
   const { data: headData } = await head(srcKey, {
     config: {
       ...config,
@@ -350,6 +352,7 @@ async function moveObject(
     },
   });
   const fileSize = headData?.size;
+  const sourceContentType = headData?.contentType;
 
   // Get source object
   const { data, error: getError } = await get(srcKey, 'stream', {
@@ -366,6 +369,7 @@ async function moveObject(
   // Put to destination
   const { error: putError } = await put(destKey, data, {
     ...calculateUploadParams(fileSize),
+    ...(sourceContentType ? { contentType: sourceContentType } : {}),
     onUploadProgress: showProgress
       ? ({ loaded }) => {
           if (fileSize !== undefined && fileSize > 0) {

--- a/src/lib/objects/put.ts
+++ b/src/lib/objects/put.ts
@@ -3,6 +3,7 @@ import { put } from '@tigrisdata/storage';
 import { failWithError, printNextActions } from '@utils/exit.js';
 import { formatOutput, formatSize } from '@utils/format.js';
 import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getContentType } from '@utils/mime.js';
 import { getFormat, getOption } from '@utils/options.js';
 import { resolveObjectArgs } from '@utils/path.js';
 import { calculateUploadParams } from '@utils/upload.js';
@@ -71,9 +72,15 @@ export default async function putObject(options: Record<string, unknown>) {
     ? calculateUploadParams(fileSize)
     : { multipart: true, partSize: 5 * 1024 * 1024, queueSize: 8 };
 
+  // --content-type wins; otherwise infer from the file extension when
+  // we have a path. Stdin uploads have no extension to infer from, so
+  // we leave it unset and let the server default apply.
+  const resolvedContentType =
+    contentType ?? (file ? getContentType(file) : undefined);
+
   const { data, error } = await put(key, body, {
     access: access === 'public' ? 'public' : 'private',
-    contentType,
+    contentType: resolvedContentType,
     ...uploadParams,
     onUploadProgress: ({ loaded, percentage }) => {
       if (fileSize !== undefined && fileSize > 0) {

--- a/src/utils/mime.ts
+++ b/src/utils/mime.ts
@@ -1,0 +1,94 @@
+import { extname } from 'path';
+
+/**
+ * Inline MIME table covering the file types commonly served from
+ * Tigris buckets. Mirrors the AWS CLI behaviour of `mimetypes.guess_type`
+ * by extension — extension-only, no content sniffing. Returns
+ * `undefined` for unknown extensions so callers omit the
+ * `Content-Type` header and let the server default apply (matches
+ * `aws s3 cp`'s behaviour, which never emits a fallback
+ * `application/octet-stream`).
+ */
+const MIME_TABLE: Record<string, string> = {
+  // Markup / scripts
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  cjs: 'text/javascript',
+  json: 'application/json',
+  map: 'application/json',
+  xml: 'application/xml',
+  svg: 'image/svg+xml',
+  webmanifest: 'application/manifest+json',
+  wasm: 'application/wasm',
+
+  // Plain text
+  txt: 'text/plain',
+  log: 'text/plain',
+  md: 'text/markdown',
+  csv: 'text/csv',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+
+  // Documents
+  pdf: 'application/pdf',
+  rtf: 'application/rtf',
+
+  // Images
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+
+  // Fonts
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  eot: 'application/vnd.ms-fontobject',
+
+  // Video
+  mp4: 'video/mp4',
+  m4v: 'video/x-m4v',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+
+  // Audio
+  mp3: 'audio/mpeg',
+  m4a: 'audio/mp4',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac',
+  aac: 'audio/aac',
+  opus: 'audio/opus',
+
+  // Archives
+  zip: 'application/zip',
+  tar: 'application/x-tar',
+  gz: 'application/gzip',
+  tgz: 'application/gzip',
+  bz2: 'application/x-bzip2',
+  '7z': 'application/x-7z-compressed',
+  rar: 'application/vnd.rar',
+};
+
+/**
+ * Look up a Content-Type from a file path's extension. Returns
+ * `undefined` when the extension is unknown — callers should omit the
+ * Content-Type rather than fall back to `application/octet-stream`.
+ */
+export function getContentType(filePath: string): string | undefined {
+  const ext = extname(filePath).slice(1).toLowerCase();
+  if (!ext) return undefined;
+  return MIME_TABLE[ext];
+}

--- a/test/utils/mime.test.ts
+++ b/test/utils/mime.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { getContentType } from '../../src/utils/mime.js';
+
+describe('getContentType', () => {
+  it('returns text/html for .html', () => {
+    expect(getContentType('foo.html')).toBe('text/html');
+    expect(getContentType('a/b/index.html')).toBe('text/html');
+  });
+
+  it('handles uppercase extensions (lowercases internally)', () => {
+    expect(getContentType('IMAGE.PNG')).toBe('image/png');
+    expect(getContentType('Foo.JPG')).toBe('image/jpeg');
+  });
+
+  it('matches the final extension only (.tar.gz → gzip)', () => {
+    expect(getContentType('archive.tar.gz')).toBe('application/gzip');
+  });
+
+  it('returns text/javascript for .js / .mjs / .cjs', () => {
+    expect(getContentType('app.js')).toBe('text/javascript');
+    expect(getContentType('app.mjs')).toBe('text/javascript');
+    expect(getContentType('app.cjs')).toBe('text/javascript');
+  });
+
+  it('returns image/svg+xml for .svg', () => {
+    expect(getContentType('logo.svg')).toBe('image/svg+xml');
+  });
+
+  it('returns undefined when the extension is unknown', () => {
+    // AWS-CLI behavior parity: callers omit the header and let the
+    // server default apply rather than emitting application/octet-stream.
+    expect(getContentType('mystery.xyz')).toBeUndefined();
+  });
+
+  it('returns undefined when there is no extension', () => {
+    expect(getContentType('Makefile')).toBeUndefined();
+    expect(getContentType('binary')).toBeUndefined();
+  });
+
+  it('returns undefined for dotfiles (no extension after the dot)', () => {
+    // extname('.gitignore') === '' — these are treated as no-extension.
+    expect(getContentType('.gitignore')).toBeUndefined();
+    expect(getContentType('.env')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Uploads via `t3 cp`, `t3 mv`, and `t3 objects put` were always landing with `Content-Type: application/octet-stream` because we never set the header. Browsers serving an HTML object would then offer it as a download instead of rendering. AWS CLI uses Python's `mimetypes.guess_type()` to derive Content-Type from the file extension; we now do the equivalent.

## Approach
- New `src/utils/mime.ts` with an inline table covering ~50 common web/dev extensions (markup, scripts, JSON, fonts, images, audio, video, archives). `getContentType()` returns `undefined` for unknown extensions so the SDK omits the header and the server default applies — same posture as `aws s3 cp` (the AWS CLI never emits a fallback `application/octet-stream` when the extension is unknown).
- Inline table chosen over a `mime-types` dep to keep the bun-compiled binary lean. Coverage matches the file types people actually serve from buckets; unknowns fall through cleanly.

## Sites updated
- `cp.ts uploadFile` (local→remote) — infer from local path.
- `cp.ts copyObject` (remote→remote) — always `head()` the source and propagate `headData.contentType`. The head call was previously gated on `showProgress`.
- `mv.ts moveObject` (remote→remote) — propagate `headData.contentType` the same way.
- `objects/put.ts` — `--content-type` still wins; otherwise infer from the file path. Stdin uploads leave it unset.
- Folder markers (zero-byte puts in cp/mv/mk/touch) are unchanged.

## Test plan
- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm test` passes (655 unit tests, +8 from new mime suite)
- [x] `npm run build` succeeds
- [ ] `t3 cp ./index.html t3://bucket/test.html` then `curl --head` confirms `Content-Type: text/html`
- [ ] `t3 cp t3://bucket/test.html t3://bucket/test-copy.html` propagates `text/html`
- [ ] `t3 mv t3://bucket/test-copy.html t3://other/test.html` propagates `text/html`
- [ ] `t3 objects put bucket/foo.css ./styles.css` lands as `text/css`
- [ ] `t3 objects put bucket/foo.css ./styles.css --content-type application/x-custom` overrides to the explicit value
- [ ] `cat ./styles.css | t3 objects put bucket/foo.css` (stdin) lands as the server default (no Content-Type sent)
- [ ] `t3 cp ./mystery.xyz t3://bucket/mystery.xyz` lands without a Content-Type header (server stores `binary/octet-stream`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes object upload/copy behavior by setting/propagating `Content-Type` and making `head()` unconditional for remote→remote operations, which could affect performance and object metadata outcomes.
> 
> **Overview**
> Fixes `t3 cp`, `t3 mv`, and `t3 objects put` to **set or preserve `Content-Type`** so uploaded/copied objects don’t default to `application/octet-stream`.
> 
> Adds `getContentType()` (extension-based MIME lookup) and uses it for local file uploads; for remote→remote `cp`/`mv`, it now always `head()`s the source and forwards `headData.contentType` to the destination. Includes new unit tests for MIME inference behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc15229ac55b9d813275d0e0f3379b542226c74d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->