### PR TITLE
fix: bump @tigrisdata/storage to 3.5.2 for SigV4 path-encoding fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/credential-providers": "^3.1038.0",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@tigrisdata/iam": "^2.1.1",
-        "@tigrisdata/storage": "^3.5.1",
+        "@tigrisdata/storage": "^3.5.2",
         "commander": "^14.0.3",
         "enquirer": "^2.4.1",
         "jose": "^6.2.3",
@@ -4032,9 +4032,9 @@
       }
     },
     "node_modules/@tigrisdata/storage": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.5.1.tgz",
-      "integrity": "sha512-52+cT33XWpTB7v0Hoin2smBesfQkSyyWXRwiAk4RDaTjXHgEPn9F4fnZZcS9D4LSeW4qgyYLBlTARxBpMy9m/g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.5.2.tgz",
+      "integrity": "sha512-VbjLO7W627Xy3iWPbbbvLMwIziZxLxfFRZyp2qGNjOE7qjy/+ADQzN0VjjiFZdVc7uL7RjHh78CGhJOjAI204A==",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@aws-sdk/credential-providers": "^3.1038.0",
     "@smithy/shared-ini-file-loader": "^4.4.9",
     "@tigrisdata/iam": "^2.1.1",
-    "@tigrisdata/storage": "^3.5.1",
+    "@tigrisdata/storage": "^3.5.2",
     "commander": "^14.0.3",
     "enquirer": "^2.4.1",
     "jose": "^6.2.3",


### PR DESCRIPTION
## Summary
Picks up `@tigrisdata/storage@3.5.2`, which fixes `403 SignatureDoesNotMatch` from `copy`, `move`, and `updateObject` when the object key contains `/` or any character that requires percent-encoding (space, `?`, `=`, etc.) and the request is signed with access-key SigV4.

This unblocks the integration tests that have been failing on `main` since #99 landed.

## Why this only broke on CI

The custom storage HTTP client takes two different auth branches:
- **OAuth / session token**: skips SigV4 signing entirely.
- **Access key**: signs with SigV4.

PR #99 was the first time `copy` and `move` got exercised under access-key auth at scale (integration tests use `TIGRIS_STORAGE_ACCESS_KEY_ID` from secrets). Local development via OAuth never hit the broken signing path, so the bug only surfaced in CI.

## What the SDK actually fixed
Two compounding encoding issues, both rooted in `@smithy/signature-v4`:

1. `SignatureV4` was constructed without `uriEscapePath: false`. The default is the AWS-standard double-encoding scheme, but S3 (and Tigris gateway) use single-encoding — so the signer re-percent-encoded path sequences (`%20` → `%2520`) while the gateway treated the wire path as already single-encoded.
2. Object keys in the request path and `X-Amz-Copy-Source` header were built with plain `encodeURIComponent`, which turned `/` into `%2F`. New `encodeObjectKey` helper splits on `/` and per-segment encodes, preserving separators.

Details: [storage#101](https://github.com/tigrisdata/storage/pull/101).

## CI failures this addresses
All 10 cp/mv regression failures observed on main since the merge of #99, including:
- `folder auto-detection > should auto-detect folder for cp/mv without trailing slash`
- `file to folder operations > should copy/move file to existing folder`
- `wildcard folder marker operations > should copy/move folder contents and marker using wildcard`
- `cp/mv - additional branches > should copy/move objects matching wildcard pattern`

The 11th failure (`objects set-access > should error on missing --access`) is a separate, pre-existing CLI quirk in `validateRequiredWhen` and is **not** in scope here.

## Test plan
- [x] `npm run format:check` and `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 659 unit/spec tests pass
- [x] `npm run build` clean
- [x] Local smoke against a real bucket with access keys:
  - `cp src.txt nested/file.txt` (nested key) — was `403`, now succeeds
  - `cp src.txt 'folder/my file.txt'` (special char) — was `403`, now succeeds
  - `mv nested/file.txt nested/renamed.txt -f` (same-bucket rename) — works
- [ ] CI integration job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patch-level dependency bump, but it changes request signing/encoding behavior in the storage client, which can affect object operations and authentication paths.
> 
> **Overview**
> Updates the CLI’s `@tigrisdata/storage` dependency from `3.5.1` to `3.5.2` (and refreshes `package-lock.json`) to pick up the upstream SigV4 path/object-key encoding fix.
> 
> This is intended to resolve `403 SignatureDoesNotMatch` failures for `copy`/`move`/`updateObject` when object keys contain `/` or other percent-encoded characters under access-key auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280e64a4d48b9e3f451782be787f2addffe6e89c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->