### PR TITLE
feat: enable/disable snapshots on an existing bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ tigris presign <path> [flags]
 | `--access-key` | Access key ID to use for signing. If not provided, resolved from credentials or auto-selected |
 | `--select` | Interactively select an access key (OAuth only) |
 | `--format` | Output format (default: url) |
+| `-snapshot, --snapshot-version` | Read from a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464). Only supported for GET requests. |
 
 **Examples:**
 ```bash
@@ -445,7 +446,10 @@ Create, inspect, update, and delete buckets. Buckets are top-level containers th
 | `tigris buckets create` (c) | Create a new bucket with optional access, tier, and location settings |
 | `tigris buckets get` (g) | Show details for a bucket including access level, region, tier, and custom domain |
 | `tigris buckets delete` (d) | Delete one or more buckets by name. The bucket must be empty or delete-protection must be off |
+| `tigris buckets restore` | Restore a soft-deleted bucket within its retention window. List recoverable buckets with "tigris buckets list --deleted" |
 | `tigris buckets set` (s) | Update settings on an existing bucket such as access level, location, caching, or custom domain |
+| `tigris buckets enable-snapshots` | Enable snapshots on an existing bucket, converting it to a snapshot bucket |
+| `tigris buckets disable-snapshots` | Disable snapshots on an existing bucket, converting it back to a regular bucket. Rejected while the bucket has dependent forks |
 | `tigris buckets set-locations` | Set the data locations for a bucket |
 | `tigris buckets set-migration` | Configure data migration from an external S3-compatible source bucket. Tigris will pull objects on demand from the source |
 | `tigris buckets migrate` | Actively migrate all objects from a shadow bucket to Tigris by scheduling server-side migration for unmigrated objects |
@@ -465,6 +469,7 @@ tigris buckets list [flags]
 |------|-------------|
 | `--format` | Output format (default: table) |
 | `--forks-of` | Only list buckets that are forks of the named source bucket |
+| `--deleted` | Only list soft-deleted buckets |
 | `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 
@@ -473,6 +478,7 @@ tigris buckets list [flags]
 tigris buckets list
 tigris buckets list --format json
 tigris buckets list --forks-of my-bucket
+tigris buckets list --deleted
 ```
 
 #### `tigris buckets create` (c)
@@ -537,6 +543,19 @@ tigris buckets delete my-bucket --yes
 tigris buckets delete bucket-a,bucket-b --yes
 ```
 
+#### `tigris buckets restore`
+
+Restore a soft-deleted bucket within its retention window. List recoverable buckets with "tigris buckets list --deleted"
+
+```
+tigris buckets restore <name>
+```
+
+**Examples:**
+```bash
+tigris buckets restore my-bucket
+```
+
 #### `tigris buckets set` (s)
 
 Update settings on an existing bucket such as access level, location, caching, or custom domain
@@ -554,6 +573,8 @@ tigris buckets set <name> [flags]
 | `--cache-control` | Default cache-control header value |
 | `--custom-domain` | Custom domain for the bucket |
 | `--enable-delete-protection` | Enable delete protection |
+| `--soft-delete` | Enable or disable soft delete (recoverable deletes). Requires --retention-days when enabling |
+| `--retention-days` | Number of days to retain soft-deleted objects (required when enabling --soft-delete) |
 | `--enable-additional-headers` | Enable additional HTTP headers (X-Content-Type-Options nosniff) |
 
 **Examples:**
@@ -561,6 +582,34 @@ tigris buckets set <name> [flags]
 tigris buckets set my-bucket --access public
 tigris buckets set my-bucket --locations iad,fra --cache-control 'max-age=3600'
 tigris buckets set my-bucket --custom-domain assets.example.com
+tigris buckets set my-bucket --soft-delete enable --retention-days 30
+tigris buckets set my-bucket --soft-delete disable
+```
+
+#### `tigris buckets enable-snapshots`
+
+Enable snapshots on an existing bucket, converting it to a snapshot bucket
+
+```
+tigris buckets enable-snapshots <name>
+```
+
+**Examples:**
+```bash
+tigris buckets enable-snapshots my-bucket
+```
+
+#### `tigris buckets disable-snapshots`
+
+Disable snapshots on an existing bucket, converting it back to a regular bucket. Rejected while the bucket has dependent forks
+
+```
+tigris buckets disable-snapshots <name>
+```
+
+**Examples:**
+```bash
+tigris buckets disable-snapshots my-bucket
 ```
 
 #### `tigris buckets set-locations`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/credential-providers": "^3.1038.0",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@tigrisdata/iam": "^2.1.1",
-        "@tigrisdata/storage": "^3.14.0",
+        "@tigrisdata/storage": "^3.15.0",
         "commander": "^14.0.3",
         "enquirer": "^2.4.1",
         "jose": "^6.2.3",
@@ -3705,9 +3705,9 @@
       }
     },
     "node_modules/@tigrisdata/storage": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.14.0.tgz",
-      "integrity": "sha512-olTU33TaYafdwAnbJJXFVQCb8T4o8Vd2zTdkG23JMsglR+xwVSgUyH/hvfPRfxpb5WynuXXqYQqIC0yirk3RIA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.15.0.tgz",
+      "integrity": "sha512-B1Og+EKdFiz6yH+jCM1JYYFjTuVL1bYh8AgrlaNN+2C5lyxllMMVdEFmonJWcfeLw7KwWxNl8IJVl5YLSemjPA==",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@aws-sdk/credential-providers": "^3.1038.0",
     "@smithy/shared-ini-file-loader": "^4.4.9",
     "@tigrisdata/iam": "^2.1.1",
-    "@tigrisdata/storage": "^3.14.0",
+    "@tigrisdata/storage": "^3.15.0",
     "commander": "^14.0.3",
     "enquirer": "^2.4.1",
     "jose": "^6.2.3",

--- a/src/lib/buckets/disable-snapshots.ts
+++ b/src/lib/buckets/disable-snapshots.ts
@@ -1,0 +1,37 @@
+import { getStorageConfigWithOrg } from '@auth/provider.js';
+import { disableSnapshot } from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('buckets', 'disable-snapshots');
+
+export default async function disableSnapshots(
+  options: Record<string, unknown>
+) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  const name = getOption<string>(options, ['name']);
+
+  if (!name) {
+    failWithError(context, 'Bucket name is required');
+  }
+
+  const finalConfig = await getStorageConfigWithOrg();
+
+  // disableSnapshot rejects when the bucket still has dependent forks; that
+  // error is surfaced as-is via failWithError.
+  const { error } = await disableSnapshot(name, { config: finalConfig });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify({ action: 'snapshots-disabled', name }));
+  }
+
+  printSuccess(context, { name });
+}

--- a/src/lib/buckets/enable-snapshots.ts
+++ b/src/lib/buckets/enable-snapshots.ts
@@ -1,0 +1,35 @@
+import { getStorageConfigWithOrg } from '@auth/provider.js';
+import { enableSnapshot } from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('buckets', 'enable-snapshots');
+
+export default async function enableSnapshots(
+  options: Record<string, unknown>
+) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  const name = getOption<string>(options, ['name']);
+
+  if (!name) {
+    failWithError(context, 'Bucket name is required');
+  }
+
+  const finalConfig = await getStorageConfigWithOrg();
+
+  const { error } = await enableSnapshot(name, { config: finalConfig });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify({ action: 'snapshots-enabled', name }));
+  }
+
+  printSuccess(context, { name });
+}

--- a/src/specs.yaml
+++ b/src/specs.yaml
@@ -873,6 +873,38 @@ commands:
           - name: enable-additional-headers
             description: Enable additional HTTP headers (X-Content-Type-Options nosniff)
             type: boolean
+      # enable-snapshots
+      - name: enable-snapshots
+        description: Enable snapshots on an existing bucket, converting it to a snapshot bucket
+        examples:
+          - "tigris buckets enable-snapshots my-bucket"
+        messages:
+          onStart: 'Enabling snapshots...'
+          onSuccess: 'Snapshots enabled for bucket {{name}}'
+          onFailure: 'Failed to enable snapshots'
+        arguments:
+          - name: name
+            description: Name of the bucket
+            type: positional
+            required: true
+            examples:
+              - my-bucket
+      # disable-snapshots
+      - name: disable-snapshots
+        description: Disable snapshots on an existing bucket, converting it back to a regular bucket. Rejected while the bucket has dependent forks
+        examples:
+          - "tigris buckets disable-snapshots my-bucket"
+        messages:
+          onStart: 'Disabling snapshots...'
+          onSuccess: 'Snapshots disabled for bucket {{name}}'
+          onFailure: 'Failed to disable snapshots'
+        arguments:
+          - name: name
+            description: Name of the bucket
+            type: positional
+            required: true
+            examples:
+              - my-bucket
       # set-ttl
       - name: set-ttl
         removed: true

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2079,6 +2079,52 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(forkBucket);
     }, 120_000);
+
+    it('should reject disable-snapshots while the bucket has dependent forks', () => {
+      // The parent must register the fork before the guard trips (eventually
+      // consistent); the preceding test already polled until it was listed.
+      let result = { stdout: '', stderr: '', exitCode: 0 };
+      for (let i = 0; i < 5; i++) {
+        result = runCli(`buckets disable-snapshots ${snapBucket}`);
+        if (result.exitCode === 1) break;
+        if (i < 4) execSync('sleep 5');
+      }
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toLowerCase()).toContain('fork');
+    }, 120_000);
+  });
+
+  describe('bucket snapshot toggle', () => {
+    const toggleBucket = `${testPrefix}-toggle`;
+
+    beforeAll(() => {
+      // Regular bucket (no --enable-snapshots) so we can turn snapshots on.
+      runCli(`mk ${toggleBucket}`);
+    });
+
+    afterAll(() => {
+      runCli(`rm ${t3(toggleBucket)} -f`);
+    });
+
+    it('should enable snapshots on an existing regular bucket', () => {
+      const result = runCli(`buckets enable-snapshots ${toggleBucket}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should output JSON with --json on enable-snapshots', () => {
+      const result = runCli(`buckets enable-snapshots ${toggleBucket} --json`);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed).toMatchObject({
+        action: 'snapshots-enabled',
+        name: toggleBucket,
+      });
+    });
+
+    it('should disable snapshots on a bucket with no forks', () => {
+      const result = runCli(`buckets disable-snapshots ${toggleBucket}`);
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe('credentials test command', () => {


### PR DESCRIPTION
## Summary

Adds two commands to switch a bucket's type **after** creation, symmetric with the existing `--enable-snapshots` create flag:

- **`tigris buckets enable-snapshots <bucket>`** — converts a regular bucket to a snapshot bucket (SDK `enableSnapshot`).
- **`tigris buckets disable-snapshots <bucket>`** — converts it back to a regular bucket (SDK `disableSnapshot`). **Rejected while the bucket has dependent forks** — a snapshot parent can't become regular while forks depend on it; the SDK's guard error is surfaced as-is.

Both support `--json` output and live alongside the other `buckets` subcommands.

Backed by [tigrisdata/storage#161](https://github.com/tigrisdata/storage/pull/161); bumps `@tigrisdata/storage` `^3.14.0 → ^3.15.0`.

## Changes

- `src/specs.yaml` — new `enable-snapshots` / `disable-snapshots` subcommands under `buckets`.
- `src/lib/buckets/enable-snapshots.ts`, `disable-snapshots.ts` — handlers mirroring the existing `set-*` pattern.
- `README.md` — regenerated from specs.
- `package.json` / `package-lock.json` — SDK bump.

## Tests

Integration tests in `test/cli.test.ts`:
- `enable-snapshots` on a regular bucket, plus `--json` output assertion.
- `disable-snapshots` on a snapshot bucket with no forks.
- `disable-snapshots` **rejected** while the bucket has a dependent fork (the guard).

These are credential-gated (`describe.skipIf`) and run the built `dist/` via `npm run test:integration`. Unit suite (684) and specs-completeness (279) pass; `tsc`, `eslint`, and `prettier --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)