### PR TITLE
release: 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ tigris presign <path> [flags]
 | `--access-key` | Access key ID to use for signing. If not provided, resolved from credentials or auto-selected |
 | `--select` | Interactively select an access key (OAuth only) |
 | `--format` | Output format (default: url) |
+| `-snapshot, --snapshot-version` | Read from a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464). Only supported for GET requests. |
 
 **Examples:**
 ```bash
@@ -445,7 +446,10 @@ Create, inspect, update, and delete buckets. Buckets are top-level containers th
 | `tigris buckets create` (c) | Create a new bucket with optional access, tier, and location settings |
 | `tigris buckets get` (g) | Show details for a bucket including access level, region, tier, and custom domain |
 | `tigris buckets delete` (d) | Delete one or more buckets by name. The bucket must be empty or delete-protection must be off |
+| `tigris buckets restore` | Restore a soft-deleted bucket within its retention window. List recoverable buckets with "tigris buckets list --deleted" |
 | `tigris buckets set` (s) | Update settings on an existing bucket such as access level, location, caching, or custom domain |
+| `tigris buckets enable-snapshots` | Enable snapshots on an existing bucket, converting it to a snapshot bucket |
+| `tigris buckets disable-snapshots` | Disable snapshots on an existing bucket, converting it back to a regular bucket. Rejected while the bucket has dependent forks |
 | `tigris buckets set-locations` | Set the data locations for a bucket |
 | `tigris buckets set-migration` | Configure data migration from an external S3-compatible source bucket. Tigris will pull objects on demand from the source |
 | `tigris buckets migrate` | Actively migrate all objects from a shadow bucket to Tigris by scheduling server-side migration for unmigrated objects |
@@ -465,6 +469,7 @@ tigris buckets list [flags]
 |------|-------------|
 | `--format` | Output format (default: table) |
 | `--forks-of` | Only list buckets that are forks of the named source bucket |
+| `--deleted` | Only list soft-deleted buckets |
 | `--limit` | Maximum number of items to return per page |
 | `-pt, --page-token` | Pagination token from a previous request to fetch the next page |
 
@@ -473,6 +478,7 @@ tigris buckets list [flags]
 tigris buckets list
 tigris buckets list --format json
 tigris buckets list --forks-of my-bucket
+tigris buckets list --deleted
 ```
 
 #### `tigris buckets create` (c)
@@ -537,6 +543,19 @@ tigris buckets delete my-bucket --yes
 tigris buckets delete bucket-a,bucket-b --yes
 ```
 
+#### `tigris buckets restore`
+
+Restore a soft-deleted bucket within its retention window. List recoverable buckets with "tigris buckets list --deleted"
+
+```
+tigris buckets restore <name>
+```
+
+**Examples:**
+```bash
+tigris buckets restore my-bucket
+```
+
 #### `tigris buckets set` (s)
 
 Update settings on an existing bucket such as access level, location, caching, or custom domain
@@ -554,6 +573,8 @@ tigris buckets set <name> [flags]
 | `--cache-control` | Default cache-control header value |
 | `--custom-domain` | Custom domain for the bucket |
 | `--enable-delete-protection` | Enable delete protection |
+| `--soft-delete` | Enable or disable soft delete (recoverable deletes). Requires --retention-days when enabling |
+| `--retention-days` | Number of days to retain soft-deleted objects (required when enabling --soft-delete) |
 | `--enable-additional-headers` | Enable additional HTTP headers (X-Content-Type-Options nosniff) |
 
 **Examples:**
@@ -561,6 +582,34 @@ tigris buckets set <name> [flags]
 tigris buckets set my-bucket --access public
 tigris buckets set my-bucket --locations iad,fra --cache-control 'max-age=3600'
 tigris buckets set my-bucket --custom-domain assets.example.com
+tigris buckets set my-bucket --soft-delete enable --retention-days 30
+tigris buckets set my-bucket --soft-delete disable
+```
+
+#### `tigris buckets enable-snapshots`
+
+Enable snapshots on an existing bucket, converting it to a snapshot bucket
+
+```
+tigris buckets enable-snapshots <name>
+```
+
+**Examples:**
+```bash
+tigris buckets enable-snapshots my-bucket
+```
+
+#### `tigris buckets disable-snapshots`
+
+Disable snapshots on an existing bucket, converting it back to a regular bucket. Rejected while the bucket has dependent forks
+
+```
+tigris buckets disable-snapshots <name>
+```
+
+**Examples:**
+```bash
+tigris buckets disable-snapshots my-bucket
 ```
 
 #### `tigris buckets set-locations`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/credential-providers": "^3.1038.0",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@tigrisdata/iam": "^2.1.1",
-        "@tigrisdata/storage": "^3.14.0",
+        "@tigrisdata/storage": "^3.15.0",
         "commander": "^14.0.3",
         "enquirer": "^2.4.1",
         "jose": "^6.2.3",
@@ -3705,9 +3705,9 @@
       }
     },
     "node_modules/@tigrisdata/storage": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.14.0.tgz",
-      "integrity": "sha512-olTU33TaYafdwAnbJJXFVQCb8T4o8Vd2zTdkG23JMsglR+xwVSgUyH/hvfPRfxpb5WynuXXqYQqIC0yirk3RIA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.15.0.tgz",
+      "integrity": "sha512-B1Og+EKdFiz6yH+jCM1JYYFjTuVL1bYh8AgrlaNN+2C5lyxllMMVdEFmonJWcfeLw7KwWxNl8IJVl5YLSemjPA==",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/credential-providers": "^3.1038.0",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@tigrisdata/iam": "^2.1.1",
-        "@tigrisdata/storage": "^3.12.0",
+        "@tigrisdata/storage": "^3.14.0",
         "commander": "^14.0.3",
         "enquirer": "^2.4.1",
         "jose": "^6.2.3",
@@ -1956,14 +1956,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -2144,9 +2144,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -2229,9 +2229,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -2246,9 +2246,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -2263,9 +2263,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -2280,9 +2280,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -2297,9 +2297,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -2314,9 +2314,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -2331,9 +2331,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -2365,9 +2365,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -2382,9 +2382,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -2399,9 +2399,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -2416,9 +2416,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -2435,9 +2435,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -2452,9 +2452,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -2469,9 +2469,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3705,9 +3705,9 @@
       }
     },
     "node_modules/@tigrisdata/storage": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.12.0.tgz",
-      "integrity": "sha512-JLCGJaKjjCb7EnQrwyRo0UBvf6V8gmnNOorLYulzeg5+7i1UzfwpwturtxJPR1KI163ySGuq1e0Ne8gnGajwdg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.14.0.tgz",
+      "integrity": "sha512-olTU33TaYafdwAnbJJXFVQCb8T4o8Vd2zTdkG23JMsglR+xwVSgUyH/hvfPRfxpb5WynuXXqYQqIC0yirk3RIA==",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -3721,9 +3721,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6414,10 +6414,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7144,9 +7154,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "dev": true,
       "funding": [
         {
@@ -7228,9 +7238,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-      "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7309,8 +7319,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.2",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -7328,27 +7338,27 @@
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.5",
-        "libnpmexec": "^10.2.5",
-        "libnpmfund": "^7.0.19",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.5",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.10",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.4",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -7358,16 +7368,16 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.4",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -7440,7 +7450,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7456,7 +7466,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.2",
+      "version": "9.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7504,7 +7514,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.1",
+      "version": "10.11.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7698,7 +7708,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -7707,7 +7717,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -7746,13 +7756,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -7821,7 +7831,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7849,7 +7859,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7918,7 +7928,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -7974,7 +7984,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -8042,7 +8052,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8141,7 +8151,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8150,12 +8160,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -8223,12 +8233,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.5",
+      "version": "8.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -8242,13 +8252,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.5",
+      "version": "10.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -8265,12 +8275,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.19",
+      "version": "7.0.24",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2"
+        "@npmcli/arborist": "^9.8.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8290,12 +8300,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.5",
+      "version": "9.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -8305,7 +8315,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8349,7 +8359,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8365,7 +8375,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -8374,7 +8384,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8397,12 +8407,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8450,34 +8460,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -8558,7 +8550,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8566,12 +8558,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -8735,7 +8727,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8796,7 +8788,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8893,7 +8885,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8917,17 +8909,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8944,12 +8936,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -9018,7 +9010,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.16",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -9046,13 +9038,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9079,7 +9071,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9111,6 +9103,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.26.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -9642,9 +9643,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -9662,7 +9663,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10002,14 +10003,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -10018,21 +10019,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rollup": {
@@ -10886,9 +10887,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11194,9 +11195,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11304,17 +11305,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -11330,7 +11331,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@aws-sdk/credential-providers": "^3.1038.0",
     "@smithy/shared-ini-file-loader": "^4.4.9",
     "@tigrisdata/iam": "^2.1.1",
-    "@tigrisdata/storage": "^3.14.0",
+    "@tigrisdata/storage": "^3.15.0",
     "commander": "^14.0.3",
     "enquirer": "^2.4.1",
     "jose": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@aws-sdk/credential-providers": "^3.1038.0",
     "@smithy/shared-ini-file-loader": "^4.4.9",
     "@tigrisdata/iam": "^2.1.1",
-    "@tigrisdata/storage": "^3.12.0",
+    "@tigrisdata/storage": "^3.14.0",
     "commander": "^14.0.3",
     "enquirer": "^2.4.1",
     "jose": "^6.2.3",

--- a/src/lib/buckets/disable-snapshots.ts
+++ b/src/lib/buckets/disable-snapshots.ts
@@ -1,0 +1,37 @@
+import { getStorageConfigWithOrg } from '@auth/provider.js';
+import { disableSnapshot } from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('buckets', 'disable-snapshots');
+
+export default async function disableSnapshots(
+  options: Record<string, unknown>
+) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  const name = getOption<string>(options, ['name']);
+
+  if (!name) {
+    failWithError(context, 'Bucket name is required');
+  }
+
+  const finalConfig = await getStorageConfigWithOrg();
+
+  // disableSnapshot rejects when the bucket still has dependent forks; that
+  // error is surfaced as-is via failWithError.
+  const { error } = await disableSnapshot(name, { config: finalConfig });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify({ action: 'snapshots-disabled', name }));
+  }
+
+  printSuccess(context, { name });
+}

--- a/src/lib/buckets/enable-snapshots.ts
+++ b/src/lib/buckets/enable-snapshots.ts
@@ -1,0 +1,35 @@
+import { getStorageConfigWithOrg } from '@auth/provider.js';
+import { enableSnapshot } from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('buckets', 'enable-snapshots');
+
+export default async function enableSnapshots(
+  options: Record<string, unknown>
+) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  const name = getOption<string>(options, ['name']);
+
+  if (!name) {
+    failWithError(context, 'Bucket name is required');
+  }
+
+  const finalConfig = await getStorageConfigWithOrg();
+
+  const { error } = await enableSnapshot(name, { config: finalConfig });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify({ action: 'snapshots-enabled', name }));
+  }
+
+  printSuccess(context, { name });
+}

--- a/src/lib/buckets/list.ts
+++ b/src/lib/buckets/list.ts
@@ -1,7 +1,7 @@
 import { getStorageConfig } from '@auth/provider.js';
 import { listBuckets, listForks } from '@tigrisdata/storage';
 import { failWithError } from '@utils/exit.js';
-import { formatOutput, formatPaginatedOutput } from '@utils/format.js';
+import { formatPaginatedOutput } from '@utils/format.js';
 import {
   msg,
   printEmpty,
@@ -19,14 +19,8 @@ export default async function list(options: Record<string, unknown>) {
   const format = getFormat(options);
   const forksOf = getOption<string>(options, ['forks-of', 'forksOf']);
   const deleted = getOption<boolean>(options, ['deleted']);
-  const { limit, pageToken, isPaginated } = getPaginationOptions(options);
+  const { limit, pageToken } = getPaginationOptions(options);
   const config = await getStorageConfig();
-
-  if (forksOf && isPaginated) {
-    console.warn(
-      '⚠ Pagination flags are ignored when --forks-of is used (all buckets are fetched for filtering)'
-    );
-  }
 
   if (forksOf && deleted) {
     console.warn(
@@ -34,9 +28,18 @@ export default async function list(options: Record<string, unknown>) {
     );
   }
 
+  const columns = [
+    { key: 'name', header: 'Name' },
+    { key: 'created', header: 'Created' },
+  ];
+
   if (forksOf) {
     // Filter for forks of the named source bucket
-    const { data, error: infoError } = await listForks(forksOf, { config });
+    const { data, error: infoError } = await listForks(forksOf, {
+      ...(limit !== undefined ? { limit } : {}),
+      ...(pageToken ? { paginationToken: pageToken } : {}),
+      config,
+    });
 
     if (infoError) {
       failWithError(context, infoError);
@@ -50,15 +53,26 @@ export default async function list(options: Record<string, unknown>) {
     const forks: Array<{ name: string; created: Date }> = [];
 
     for (const bucket of data.forks) {
-      forks.push({ name: bucket.name, created: bucket.creationDate });
+      forks.push({ name: bucket.name!, created: bucket.creationDate! });
     }
 
-    const output = formatOutput(forks, format!, 'forks', 'fork', [
-      { key: 'name', header: 'Name' },
-      { key: 'created', header: 'Created' },
-    ]);
+    const nextToken = data.paginationToken || undefined;
+
+    const output = formatPaginatedOutput(
+      forks,
+      format!,
+      'forks',
+      'fork',
+      columns,
+      { paginationToken: nextToken }
+    );
 
     console.log(output);
+
+    if (format !== 'json' && format !== 'xml') {
+      printPaginationHint(nextToken);
+    }
+
     printSuccess(context, { count: forks.length });
     return;
   }
@@ -83,11 +97,6 @@ export default async function list(options: Record<string, unknown>) {
     name: bucket.name,
     created: bucket.creationDate,
   }));
-
-  const columns = [
-    { key: 'name', header: 'Name' },
-    { key: 'created', header: 'Created' },
-  ];
 
   const nextToken = data.paginationToken || undefined;
 

--- a/src/lib/presign.ts
+++ b/src/lib/presign.ts
@@ -37,6 +37,16 @@ export default async function presign(options: Record<string, unknown>) {
   const accessKeyFlag = getOption<string>(options, ['access-key', 'accessKey']);
   const selectFlag = getOption<boolean>(options, ['select']);
 
+  const snapshotVersion = getOption<string>(options, [
+    'snapshot-version',
+    'snapshotVersion',
+    'snapshot',
+  ]);
+
+  if (snapshotVersion && method !== 'get') {
+    exitWithError('Snapshot version is only supported for GET requests');
+  }
+
   const config = await getStorageConfig();
 
   // Resolve access key ID
@@ -75,6 +85,7 @@ export default async function presign(options: Record<string, unknown>) {
     method: method as 'get' | 'put',
     expiresIn,
     accessKeyId,
+    ...(snapshotVersion ? { snapshotVersion } : {}),
     config: {
       ...config,
       bucket,

--- a/src/specs.yaml
+++ b/src/specs.yaml
@@ -873,6 +873,38 @@ commands:
           - name: enable-additional-headers
             description: Enable additional HTTP headers (X-Content-Type-Options nosniff)
             type: boolean
+      # enable-snapshots
+      - name: enable-snapshots
+        description: Enable snapshots on an existing bucket, converting it to a snapshot bucket
+        examples:
+          - "tigris buckets enable-snapshots my-bucket"
+        messages:
+          onStart: 'Enabling snapshots...'
+          onSuccess: 'Snapshots enabled for bucket {{name}}'
+          onFailure: 'Failed to enable snapshots'
+        arguments:
+          - name: name
+            description: Name of the bucket
+            type: positional
+            required: true
+            examples:
+              - my-bucket
+      # disable-snapshots
+      - name: disable-snapshots
+        description: Disable snapshots on an existing bucket, converting it back to a regular bucket. Rejected while the bucket has dependent forks
+        examples:
+          - "tigris buckets disable-snapshots my-bucket"
+        messages:
+          onStart: 'Disabling snapshots...'
+          onSuccess: 'Snapshots disabled for bucket {{name}}'
+          onFailure: 'Failed to disable snapshots'
+        arguments:
+          - name: name
+            description: Name of the bucket
+            type: positional
+            required: true
+            examples:
+              - my-bucket
       # set-ttl
       - name: set-ttl
         removed: true

--- a/src/specs.yaml
+++ b/src/specs.yaml
@@ -437,6 +437,9 @@ commands:
         description: Output format
         options: [url, json]
         default: url
+      - name: snapshot-version
+        description: Read from a specific bucket snapshot. Accepts a snapshot version string or any UNIX nanosecond-precision timestamp (e.g. 1765889000501544464). Only supported for GET requests.
+        alias: snapshot
 
   # cp
   - name: cp

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1270,9 +1270,17 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
   describe('presign command', () => {
     const accessKey = process.env.TIGRIS_STORAGE_ACCESS_KEY_ID!;
+    let snapshotVersion: string;
 
     beforeAll(() => {
       runCli(`touch ${testBucket}/presign-test.txt`);
+      // Take a real snapshot AFTER creating the object so the snapshot
+      // version post-dates the object. The SDK resolves --snapshot-version
+      // by finding an object version <= the snapshot version, so a hardcoded
+      // timestamp can never match a freshly-created object.
+      runCli(`snapshots take ${testBucket}`);
+      const list = runCli(`snapshots list ${testBucket} --format json`);
+      snapshotVersion = JSON.parse(list.stdout.trim()).items[0].version;
     });
 
     afterAll(() => {
@@ -1338,7 +1346,7 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
     it('should generate presigned GET URL with --snapshot-version', () => {
       const result = runCli(
-        `presign ${testBucket}/presign-test.txt --snapshot-version 1765889000501544464 --access-key ${accessKey}`
+        `presign ${testBucket}/presign-test.txt --snapshot-version ${snapshotVersion} --access-key ${accessKey}`
       );
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toMatch(/^https:\/\//);
@@ -1346,7 +1354,7 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
     it('should accept the --snapshot alias for GET', () => {
       const result = runCli(
-        `presign ${testBucket}/presign-test.txt --snapshot 1765889000501544464 --access-key ${accessKey}`
+        `presign ${testBucket}/presign-test.txt --snapshot ${snapshotVersion} --access-key ${accessKey}`
       );
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toMatch(/^https:\/\//);
@@ -1354,7 +1362,7 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
     it('should reject --snapshot-version with --method put', () => {
       const result = runCli(
-        `presign ${testBucket}/presign-test.txt --method put --snapshot-version 1765889000501544464 --access-key ${accessKey}`
+        `presign ${testBucket}/presign-test.txt --method put --snapshot-version ${snapshotVersion} --access-key ${accessKey}`
       );
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2104,14 +2104,19 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
   describe('bucket snapshot toggle', () => {
     const toggleBucket = `${testPrefix}-toggle`;
+    // Separate fresh bucket: enabling snapshots on an already-enabled bucket
+    // is rejected, so the --json test needs its own regular bucket to enable.
+    const toggleJsonBucket = `${testPrefix}-toggle-json`;
 
     beforeAll(() => {
-      // Regular bucket (no --enable-snapshots) so we can turn snapshots on.
+      // Regular buckets (no --enable-snapshots) so we can turn snapshots on.
       runCli(`mk ${toggleBucket}`);
+      runCli(`mk ${toggleJsonBucket}`);
     });
 
     afterAll(() => {
       runCli(`rm ${t3(toggleBucket)} -f`);
+      runCli(`rm ${t3(toggleJsonBucket)} -f`);
     });
 
     it('should enable snapshots on an existing regular bucket', () => {
@@ -2120,12 +2125,14 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
     });
 
     it('should output JSON with --json on enable-snapshots', () => {
-      const result = runCli(`buckets enable-snapshots ${toggleBucket} --json`);
+      const result = runCli(
+        `buckets enable-snapshots ${toggleJsonBucket} --json`
+      );
       expect(result.exitCode).toBe(0);
       const parsed = JSON.parse(result.stdout.trim());
       expect(parsed).toMatchObject({
         action: 'snapshots-enabled',
-        name: toggleBucket,
+        name: toggleJsonBucket,
       });
     });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2079,6 +2079,52 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(forkBucket);
     }, 120_000);
+
+    it('should reject disable-snapshots while the bucket has dependent forks', () => {
+      // The parent must register the fork before the guard trips (eventually
+      // consistent); the preceding test already polled until it was listed.
+      let result = { stdout: '', stderr: '', exitCode: 0 };
+      for (let i = 0; i < 5; i++) {
+        result = runCli(`buckets disable-snapshots ${snapBucket}`);
+        if (result.exitCode === 1) break;
+        if (i < 4) execSync('sleep 5');
+      }
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toLowerCase()).toContain('fork');
+    }, 120_000);
+  });
+
+  describe('bucket snapshot toggle', () => {
+    const toggleBucket = `${testPrefix}-toggle`;
+
+    beforeAll(() => {
+      // Regular bucket (no --enable-snapshots) so we can turn snapshots on.
+      runCli(`mk ${toggleBucket}`);
+    });
+
+    afterAll(() => {
+      runCli(`rm ${t3(toggleBucket)} -f`);
+    });
+
+    it('should enable snapshots on an existing regular bucket', () => {
+      const result = runCli(`buckets enable-snapshots ${toggleBucket}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should output JSON with --json on enable-snapshots', () => {
+      const result = runCli(`buckets enable-snapshots ${toggleBucket} --json`);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed).toMatchObject({
+        action: 'snapshots-enabled',
+        name: toggleBucket,
+      });
+    });
+
+    it('should disable snapshots on a bucket with no forks', () => {
+      const result = runCli(`buckets disable-snapshots ${toggleBucket}`);
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe('credentials test command', () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1335,6 +1335,32 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Object key is required');
     });
+
+    it('should generate presigned GET URL with --snapshot-version', () => {
+      const result = runCli(
+        `presign ${testBucket}/presign-test.txt --snapshot-version 1765889000501544464 --access-key ${accessKey}`
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toMatch(/^https:\/\//);
+    });
+
+    it('should accept the --snapshot alias for GET', () => {
+      const result = runCli(
+        `presign ${testBucket}/presign-test.txt --snapshot 1765889000501544464 --access-key ${accessKey}`
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toMatch(/^https:\/\//);
+    });
+
+    it('should reject --snapshot-version with --method put', () => {
+      const result = runCli(
+        `presign ${testBucket}/presign-test.txt --method put --snapshot-version 1765889000501544464 --access-key ${accessKey}`
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'Snapshot version is only supported for GET requests'
+      );
+    });
   });
 
   describe('buckets list command', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New bucket mutation commands and presigned URL behavior at a snapshot version affect how users access data; changes are SDK-backed with integration tests but touch production bucket configuration.
> 
> **Overview**
> **Release 3.2.0** bumps **`@tigrisdata/storage`** to **^3.15.0** and wires new platform APIs into the CLI, with README/spec updates for soft-delete, restore, and snapshot workflows.
> 
> Adds **`tigris buckets enable-snapshots`** and **`tigris buckets disable-snapshots`** (SDK `enableSnapshot` / `disableSnapshot`, JSON action output). **`tigris presign`** accepts **`--snapshot-version`** / **`--snapshot`** for **GET** only and forwards it to `getPresignedUrl`; PUT is rejected client-side.
> 
> **`tigris buckets list --forks-of`** now paginates via `listForks` (limit/page token + pagination hints) instead of loading all forks and filtering locally. Docs also cover **`--deleted`**, restore, and bucket **`--soft-delete`** / **`--retention-days`**.
> 
> Integration tests cover presign-at-snapshot, snapshot enable/disable (including fork guard on disable), and related bucket flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558391d75a4aa98cdd8c0fce57f931cc2246601e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->