### PR TITLE
fix(test): use a real snapshot version in presign integration tests

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1270,9 +1270,17 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
   describe('presign command', () => {
     const accessKey = process.env.TIGRIS_STORAGE_ACCESS_KEY_ID!;
+    let snapshotVersion: string;
 
     beforeAll(() => {
       runCli(`touch ${testBucket}/presign-test.txt`);
+      // Take a real snapshot AFTER creating the object so the snapshot
+      // version post-dates the object. The SDK resolves --snapshot-version
+      // by finding an object version <= the snapshot version, so a hardcoded
+      // timestamp can never match a freshly-created object.
+      runCli(`snapshots take ${testBucket}`);
+      const list = runCli(`snapshots list ${testBucket} --format json`);
+      snapshotVersion = JSON.parse(list.stdout.trim()).items[0].version;
     });
 
     afterAll(() => {
@@ -1338,7 +1346,7 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
     it('should generate presigned GET URL with --snapshot-version', () => {
       const result = runCli(
-        `presign ${testBucket}/presign-test.txt --snapshot-version 1765889000501544464 --access-key ${accessKey}`
+        `presign ${testBucket}/presign-test.txt --snapshot-version ${snapshotVersion} --access-key ${accessKey}`
       );
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toMatch(/^https:\/\//);
@@ -1346,7 +1354,7 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
     it('should accept the --snapshot alias for GET', () => {
       const result = runCli(
-        `presign ${testBucket}/presign-test.txt --snapshot 1765889000501544464 --access-key ${accessKey}`
+        `presign ${testBucket}/presign-test.txt --snapshot ${snapshotVersion} --access-key ${accessKey}`
       );
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toMatch(/^https:\/\//);
@@ -1354,7 +1362,7 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
     it('should reject --snapshot-version with --method put', () => {
       const result = runCli(
-        `presign ${testBucket}/presign-test.txt --method put --snapshot-version 1765889000501544464 --access-key ${accessKey}`
+        `presign ${testBucket}/presign-test.txt --method put --snapshot-version ${snapshotVersion} --access-key ${accessKey}`
       );
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(


### PR DESCRIPTION
## Problem

The two presign `--snapshot-version` integration tests fail on the push-triggered CI run ([example](https://github.com/tigrisdata/cli/actions/runs/27960874693/job/82743290149?pr=112)) with `expected 1 to be +0` — the CLI exits `1` instead of `0`.

They hardcoded a snapshot version `1765889000501544464` (= `2025-12-16T12:43:20Z`), but `presign-test.txt` is created fresh in `beforeAll` at test runtime. The storage SDK resolves `--snapshot-version` by finding an object version with `versionId <= snapshotVersion`; the freshly-created object's version always post-dates the hardcoded timestamp, so no version qualifies and the SDK returns `Object "presign-test.txt" did not exist at snapshot version ...`.

It went unnoticed until now because the integration job only runs on `push`/`workflow_dispatch` (not `pull_request`), so the test had never actually executed before.

## Fix

Take a real snapshot of `testBucket` *after* creating the object and presign against its version, mirroring the existing `ls`/`stat` snapshot tests. The snapshot version now post-dates the object, so resolution succeeds.

## Verification

- `tsc --noEmit`, `npm run lint`, `npm run format:check` all pass.
- Integration behavior validated by the push-triggered CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in integration setup; no production CLI or SDK behavior is modified.
> 
> **Overview**
> Fixes flaky/failing **presign** integration tests that passed a **hardcoded** `--snapshot-version` while `presign-test.txt` is created at runtime. Snapshot resolution needs an object version **≤** the snapshot version, so the fixed timestamp could never match a fresh object and the CLI exited with an error.
> 
> The **presign** `beforeAll` now **takes a snapshot after** creating the object and reads the version from `snapshots list --format json`, then uses that value in the `--snapshot-version`, `--snapshot`, and PUT-rejection cases—same pattern as other snapshot integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e4aef39342a563ead78d1c816c1b35731ee413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->