### PR TITLE
fix(test): enable snapshots --json on a fresh bucket

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2104,14 +2104,19 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
 
   describe('bucket snapshot toggle', () => {
     const toggleBucket = `${testPrefix}-toggle`;
+    // Separate fresh bucket: enabling snapshots on an already-enabled bucket
+    // is rejected, so the --json test needs its own regular bucket to enable.
+    const toggleJsonBucket = `${testPrefix}-toggle-json`;
 
     beforeAll(() => {
-      // Regular bucket (no --enable-snapshots) so we can turn snapshots on.
+      // Regular buckets (no --enable-snapshots) so we can turn snapshots on.
       runCli(`mk ${toggleBucket}`);
+      runCli(`mk ${toggleJsonBucket}`);
     });
 
     afterAll(() => {
       runCli(`rm ${t3(toggleBucket)} -f`);
+      runCli(`rm ${t3(toggleJsonBucket)} -f`);
     });
 
     it('should enable snapshots on an existing regular bucket', () => {
@@ -2120,12 +2125,14 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
     });
 
     it('should output JSON with --json on enable-snapshots', () => {
-      const result = runCli(`buckets enable-snapshots ${toggleBucket} --json`);
+      const result = runCli(
+        `buckets enable-snapshots ${toggleJsonBucket} --json`
+      );
       expect(result.exitCode).toBe(0);
       const parsed = JSON.parse(result.stdout.trim());
       expect(parsed).toMatchObject({
         action: 'snapshots-enabled',
-        name: toggleBucket,
+        name: toggleJsonBucket,
       });
     });
 


### PR DESCRIPTION
## Problem

The `bucket snapshot toggle > should output JSON with --json on enable-snapshots` integration test fails with `expected 1 to be +0` — the CLI exits `1` instead of `0`.

The test before it (`should enable snapshots on an existing regular bucket`) already turns `toggleBucket` into a snapshot bucket. The `--json` test then re-enables the *same* bucket. Setting the bucket type to Snapshot when it's already Snapshot is rejected by the server, so the CLI exits `1`.

The bug is pre-existing on `main` (from #111). It only surfaces on `push`/`workflow_dispatch` runs, since the integration job doesn't run on PR events.

## Fix

Give the `--json` test its own fresh regular bucket, matching how the storage SDK's own `setBucketType`/`enableSnapshot` tests always enable on a newly-created bucket.

## Verification

- `tsc --noEmit`, `npm run lint`, `npm run format:check` all pass.
- Integration behavior is validated by the `main` integration run (not PR CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in `test/cli.test.ts`; no production CLI or API behavior is modified.
> 
> **Overview**
> Fixes a flaky **bucket snapshot toggle** integration test where `buckets enable-snapshots … --json` ran on the same bucket as the prior “enable snapshots” case. After that first test, the bucket is already snapshot-enabled; enabling again is rejected by the API and the CLI exits **1**, so the JSON assertion failed.
> 
> The PR adds a dedicated regular bucket (`toggleJsonBucket`) for the `--json` test, created and torn down alongside the existing toggle bucket, so **enable-snapshots** runs on a fresh bucket and can succeed with `action: 'snapshots-enabled'` in stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e64e10c85679ca9747f8940517fab42434ccbb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->