### PR TITLE
release: 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,8 @@ Low-level object operations for listing, downloading, uploading, and deleting in
 | `tigris objects set` (s) | (Deprecated) Update settings on an existing object such as access level. Use `tigris objects set-access` for ACL changes and `tigris mv` to rename |
 | `tigris objects set-access` (sa) | Set the access level (public or private) on an existing object |
 | `tigris objects info` (i) | Show metadata for an object (content type, size, modified date) |
+| `tigris objects restore` (rs) | Restore an archived object (e.g. one in the GLACIER tier) into an actively-readable copy for a number of days |
+| `tigris objects restore-info` (ri) | Show the restore state of an archived object (archived, in-progress, or restored) |
 
 #### `tigris objects list` (l)
 
@@ -1050,6 +1052,46 @@ tigris objects info my-bucket report.pdf
 tigris objects info t3://my-bucket/report.pdf
 tigris objects info my-bucket report.pdf --format json
 tigris objects info my-bucket report.pdf --version-id abc123
+```
+
+#### `tigris objects restore` (rs)
+
+Restore an archived object (e.g. one in the GLACIER tier) into an actively-readable copy for a number of days
+
+```
+tigris objects restore <bucket> [key] [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-d, --days` | How many days the restored copy stays available before reverting to its archived tier (default: 1) |
+| `--version-id` | Restore a specific object version (requires bucket versioning). Omit to restore the current version |
+| `--format` | Output format (default: table) |
+
+**Examples:**
+```bash
+tigris objects restore my-bucket archived.bin
+tigris objects restore my-bucket archived.bin --days 3
+tigris objects restore t3://my-bucket/archived.bin --days 7
+```
+
+#### `tigris objects restore-info` (ri)
+
+Show the restore state of an archived object (archived, in-progress, or restored)
+
+```
+tigris objects restore-info <bucket> [key] [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--version-id` | Inspect a specific object version (requires bucket versioning). Omit to read the current version |
+| `--format` | Output format (default: table) |
+
+**Examples:**
+```bash
+tigris objects restore-info my-bucket archived.bin
+tigris objects restore-info t3://my-bucket/archived.bin --format json
 ```
 
 ### `tigris access-keys` (keys)

--- a/README.md
+++ b/README.md
@@ -1276,6 +1276,7 @@ Identity and Access Management - manage policies, users, and permissions
 |---------|-------------|
 | `tigris iam policies` (p) | Manage IAM policies. Policies define permissions for access keys |
 | `tigris iam users` (u) | Manage organization users and invitations |
+| `tigris iam teams` (t) | Manage organization teams |
 
 #### `tigris iam policies` (p)
 
@@ -1547,6 +1548,75 @@ tigris iam users remove [resource] [flags]
 tigris iam users remove
 tigris iam users remove user@example.com --yes
 tigris iam users remove user@example.com,user@example.net --yes
+```
+
+#### `tigris iam teams` (t)
+
+Manage organization teams
+
+| Command | Description |
+|---------|-------------|
+| `tigris iam teams list` (l) | List all teams in the organization |
+| `tigris iam teams create` (c) | Create a new team in the organization |
+| `tigris iam teams edit` (e) | Update a team's name, description, or members. Members are replaced with the provided list |
+
+##### `tigris iam teams list` (l)
+
+List all teams in the organization
+
+```
+tigris iam teams list [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format (default: table) |
+
+**Examples:**
+```bash
+tigris iam teams list
+tigris iam teams list --format json
+```
+
+##### `tigris iam teams create` (c)
+
+Create a new team in the organization
+
+```
+tigris iam teams create <name> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-d, --description` | Description for the team |
+| `-m, --members` | Member email address(es) to add (comma-separated for multiple) |
+
+**Examples:**
+```bash
+tigris iam teams create engineering
+tigris iam teams create engineering --description 'Engineering team'
+tigris iam teams create engineering --members a@example.com,b@example.com
+```
+
+##### `tigris iam teams edit` (e)
+
+Update a team's name, description, or members. Members are replaced with the provided list
+
+```
+tigris iam teams edit <id> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-n, --name` | New name for the team |
+| `-d, --description` | New description for the team |
+| `-m, --members` | Replace the team's members with these email address(es) (comma-separated for multiple) |
+
+**Examples:**
+```bash
+tigris iam teams edit team_id --name platform
+tigris iam teams edit team_id --description 'Platform team'
+tigris iam teams edit team_id --members a@example.com,b@example.com
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ tigris mk <path> [flags]
 | `-a, --access` | Access level (only applies when creating a bucket) (default: private) |
 | `--public` | Shorthand for --access public (only applies when creating a bucket) |
 | `-s, --enable-snapshots` | Enable snapshots for the bucket (only applies when creating a bucket) (default: false) |
+| `--allow-object-acl` | Allow per-object ACLs on the bucket (only applies when creating a bucket) (default: false) |
+| `--enable-directory-listing` | Enable directory listing, relevant for public buckets (only applies when creating a bucket) (default: false) |
 | `-t, --default-tier` | Default storage tier (only applies when creating a bucket) (default: STANDARD) |
 | `-l, --locations` | Location for the bucket (only applies when creating a bucket) (default: global) |
 | `-fork, --fork-of` | Create this bucket as a fork (copy-on-write clone) of the named source bucket |
@@ -231,6 +233,8 @@ tigris mk <path> [flags]
 ```bash
 tigris mk my-bucket
 tigris mk my-bucket --access public --region iad
+tigris mk my-bucket --allow-object-acl
+tigris mk my-bucket --public --enable-directory-listing
 tigris mk my-bucket/images/
 tigris mk t3://my-bucket
 tigris mk my-fork --fork-of my-bucket
@@ -308,10 +312,12 @@ tigris cp <src> <dest> [flags]
 | Flag | Description |
 |------|-------------|
 | `-r, --recursive` | Copy directories recursively |
+| `-a, --access` | Access level for uploaded objects (only applies to local-to-remote uploads) |
 
 **Examples:**
 ```bash
 tigris cp ./file.txt t3://my-bucket/file.txt
+tigris cp ./logo.png t3://my-bucket/logo.png --access public
 tigris cp t3://my-bucket/file.txt ./local-copy.txt
 tigris cp t3://my-bucket/src/ t3://my-bucket/dest/ -r
 tigris cp ./images/ t3://my-bucket/images/ -r
@@ -494,6 +500,8 @@ tigris buckets create [name] [flags]
 | `-a, --access` | Access level (default: private) |
 | `--public` | Shorthand for --access public |
 | `-s, --enable-snapshots` | Enable snapshots for the bucket (default: false) |
+| `--allow-object-acl` | Allow per-object ACLs on the bucket (default: false) |
+| `--enable-directory-listing` | Enable directory listing, relevant for public buckets (default: false) |
 | `-t, --default-tier` | Choose the default tier for the bucket (default: STANDARD) |
 | `-l, --locations` | Location for the bucket (default: global) |
 | `-fork, --fork-of` | Create this bucket as a fork (copy-on-write clone) of the named source bucket |
@@ -504,6 +512,8 @@ tigris buckets create [name] [flags]
 tigris buckets create my-bucket
 tigris buckets create my-bucket --access public --locations iad
 tigris buckets create my-bucket --enable-snapshots --default-tier STANDARD_IA
+tigris buckets create my-bucket --allow-object-acl
+tigris buckets create my-bucket --public --enable-directory-listing
 tigris buckets create my-fork --fork-of my-bucket
 tigris buckets create my-fork --fork-of my-bucket --source-snapshot 1765889000501544464
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1038.0",
         "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@tigrisdata/iam": "^2.1.1",
-        "@tigrisdata/storage": "^3.15.0",
+        "@tigrisdata/iam": "^2.2.0",
+        "@tigrisdata/storage": "^3.16.0",
         "commander": "^14.0.3",
         "enquirer": "^2.4.1",
         "jose": "^6.2.3",
@@ -3696,18 +3696,18 @@
       "license": "MIT"
     },
     "node_modules/@tigrisdata/iam": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/iam/-/iam-2.1.1.tgz",
-      "integrity": "sha512-l9mjTnFpWGi+Nzved836qM7R/2Qm47kDmfsiHFTO7++y9I12XokpbXhFACsShhlrrWY2seSKn1wkrM8dpRXCDg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/iam/-/iam-2.2.0.tgz",
+      "integrity": "sha512-tfHmBV4BjHOln/MxGUIIC3zCbUyyuW6eYDxzKpJwcKrvTPfrAqstfhJXD4ubBxk+QK3TlKixXcZMfLGYbE/MQw==",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.4.2"
       }
     },
     "node_modules/@tigrisdata/storage": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.15.0.tgz",
-      "integrity": "sha512-B1Og+EKdFiz6yH+jCM1JYYFjTuVL1bYh8AgrlaNN+2C5lyxllMMVdEFmonJWcfeLw7KwWxNl8IJVl5YLSemjPA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@tigrisdata/storage/-/storage-3.16.0.tgz",
+      "integrity": "sha512-Tdqh94A8gEj9GUF6fWGibO3Dz3l3BBieNMFh26PXUuBOTOpHEbPitg/zELopboVTRtRzWNsWnUFGymjxHYlpZA==",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.1038.0",
     "@smithy/shared-ini-file-loader": "^4.4.9",
-    "@tigrisdata/iam": "^2.1.1",
-    "@tigrisdata/storage": "^3.15.0",
+    "@tigrisdata/iam": "^2.2.0",
+    "@tigrisdata/storage": "^3.16.0",
     "commander": "^14.0.3",
     "enquirer": "^2.4.1",
     "jose": "^6.2.3",

--- a/src/lib/buckets/create.ts
+++ b/src/lib/buckets/create.ts
@@ -32,6 +32,14 @@ export default async function create(options: Record<string, unknown>) {
     's',
     'S',
   ]);
+  const allowObjectAcl = getOption<boolean>(options, [
+    'allow-object-acl',
+    'allowObjectAcl',
+  ]);
+  const enableDirectoryListing = getOption<boolean>(options, [
+    'enable-directory-listing',
+    'enableDirectoryListing',
+  ]);
   let defaultTier = getOption<string>(options, ['default-tier', 't', 'T']);
   const locations = getOption<string>(options, ['locations', 'l', 'L']);
   const forkOf = getOption<string>(options, ['fork-of', 'forkOf', 'fork']);
@@ -120,6 +128,8 @@ export default async function create(options: Record<string, unknown>) {
   const { error } = await createBucket(name, {
     defaultTier: (defaultTier ?? 'STANDARD') as StorageClass,
     enableSnapshot: enableSnapshots === true,
+    allowObjectAcl: allowObjectAcl === true,
+    enableDirectoryListing: enableDirectoryListing === true,
     access: (access ?? 'private') as 'public' | 'private',
     locations: parsedLocations ?? parseLocations(locations ?? 'global'),
     ...(forkOf ? { sourceBucketName: forkOf } : {}),

--- a/src/lib/cp.ts
+++ b/src/lib/cp.ts
@@ -101,7 +101,8 @@ async function uploadFile(
   bucket: string,
   key: string,
   config: Awaited<ReturnType<typeof getStorageConfig>>,
-  showProgress = false
+  showProgress = false,
+  access?: 'public' | 'private'
 ): Promise<{ error?: string }> {
   let fileSize: number | undefined;
   try {
@@ -119,6 +120,7 @@ async function uploadFile(
   const { error: putError } = await put(key, body, {
     ...calculateUploadParams(fileSize),
     ...(contentType ? { contentType } : {}),
+    ...(access ? { access } : {}),
     onUploadProgress: showProgress
       ? ({ loaded }) => {
           if (fileSize !== undefined && fileSize > 0) {
@@ -253,7 +255,8 @@ async function copyLocalToRemote(
   src: string,
   destParsed: ParsedPath,
   config: Awaited<ReturnType<typeof getStorageConfig>>,
-  recursive: boolean
+  recursive: boolean,
+  access?: 'public' | 'private'
 ) {
   const localPath = resolveLocalPath(src);
   const isWildcard = src.includes('*');
@@ -282,7 +285,14 @@ async function copyLocalToRemote(
         ? `${destParsed.path.replace(/\/$/, '')}/${relPath}`
         : relPath;
 
-      const result = await uploadFile(file, destParsed.bucket, destKey, config);
+      const result = await uploadFile(
+        file,
+        destParsed.bucket,
+        destKey,
+        config,
+        false,
+        access
+      );
       if (result.error) {
         console.error(`Failed to upload ${file}: ${result.error}`);
         return false;
@@ -352,7 +362,14 @@ async function copyLocalToRemote(
       ].filter(Boolean);
       const destKey = parts.join('/');
 
-      const result = await uploadFile(file, destParsed.bucket, destKey, config);
+      const result = await uploadFile(
+        file,
+        destParsed.bucket,
+        destKey,
+        config,
+        false,
+        access
+      );
       if (result.error) {
         console.error(`Failed to upload ${file}: ${result.error}`);
         return false;
@@ -405,7 +422,8 @@ async function copyLocalToRemote(
       destParsed.bucket,
       destKey,
       config,
-      !_jsonMode
+      !_jsonMode,
+      access
     );
     if (result.error) {
       exitWithError(result.error);
@@ -824,10 +842,29 @@ export default async function cp(options: Record<string, unknown>) {
   }
 
   const recursive = !!getOption<boolean>(options, ['recursive', 'r']);
+  const accessArg = getOption<string>(options, ['access', 'a', 'A']);
   const format = getFormat(options);
   _jsonMode = format === 'json';
 
+  let access: 'public' | 'private' | undefined;
+  if (accessArg === undefined) {
+    access = undefined;
+  } else if (accessArg === 'public' || accessArg === 'private') {
+    access = accessArg;
+  } else {
+    exitWithError('Access level must be either "public" or "private"');
+  }
+
   const direction = detectDirection(src, dest);
+
+  // --access only affects the object being written, which only happens on
+  // upload. copy() can't carry access and a downloaded file has none.
+  if (access !== undefined && direction !== 'local-to-remote') {
+    exitWithError(
+      '--access only applies to local-to-remote uploads. Use "tigris objects set-access" to change access on existing objects.'
+    );
+  }
+
   const config = await getStorageConfig({ withCredentialProvider: true });
 
   switch (direction) {
@@ -836,7 +873,7 @@ export default async function cp(options: Record<string, unknown>) {
       if (!destParsed.bucket) {
         exitWithError('Invalid destination path');
       }
-      await copyLocalToRemote(src, destParsed, config, recursive);
+      await copyLocalToRemote(src, destParsed, config, recursive, access);
       break;
     }
     case 'remote-to-local': {

--- a/src/lib/iam/teams/create.ts
+++ b/src/lib/iam/teams/create.ts
@@ -4,6 +4,8 @@ import { failWithError } from '@utils/exit.js';
 import { msg, printStart, printSuccess } from '@utils/messages.js';
 import { getFormat, getOption } from '@utils/options.js';
 
+import { parseMembers } from './shared.js';
+
 const context = msg('iam teams', 'create');
 
 export default async function create(options: Record<string, unknown>) {
@@ -14,18 +16,20 @@ export default async function create(options: Record<string, unknown>) {
   if (isFlyOrganization('Team management')) return;
 
   const name = getOption<string>(options, ['name']);
-  const description = getOption<string>(options, ['description', 'd']);
-  const membersOption = getOption<string | string[]>(options, ['members', 'm']);
+  const descriptionRaw = getOption<string | boolean>(options, [
+    'description',
+    'd',
+  ]);
+  const description =
+    typeof descriptionRaw === 'string' ? descriptionRaw : undefined;
+  const members = parseMembers(
+    context,
+    getOption<string | string[] | boolean>(options, ['members', 'm'])
+  );
 
   if (!name) {
     failWithError(context, 'Team name is required');
   }
-
-  const members = Array.isArray(membersOption)
-    ? membersOption
-    : membersOption
-      ? [membersOption]
-      : undefined;
 
   const iamConfig = await getOAuthIAMConfig(context);
 

--- a/src/lib/iam/teams/create.ts
+++ b/src/lib/iam/teams/create.ts
@@ -1,0 +1,53 @@
+import { getOAuthIAMConfig, isFlyOrganization } from '@auth/iam.js';
+import { createTeam } from '@tigrisdata/iam';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('iam teams', 'create');
+
+export default async function create(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  if (isFlyOrganization('Team management')) return;
+
+  const name = getOption<string>(options, ['name']);
+  const description = getOption<string>(options, ['description', 'd']);
+  const membersOption = getOption<string | string[]>(options, ['members', 'm']);
+
+  if (!name) {
+    failWithError(context, 'Team name is required');
+  }
+
+  const members = Array.isArray(membersOption)
+    ? membersOption
+    : membersOption
+      ? [membersOption]
+      : undefined;
+
+  const iamConfig = await getOAuthIAMConfig(context);
+
+  const { data, error } = await createTeam(
+    {
+      name,
+      ...(description !== undefined ? { description } : {}),
+      ...(members ? { members } : {}),
+    },
+    { config: iamConfig }
+  );
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(
+      JSON.stringify({ action: 'created', teamId: data.teamId, name })
+    );
+  }
+
+  printSuccess(context, { name });
+  console.log(`Team ID: ${data.teamId}`);
+}

--- a/src/lib/iam/teams/create.ts
+++ b/src/lib/iam/teams/create.ts
@@ -46,6 +46,7 @@ export default async function create(options: Record<string, unknown>) {
     console.log(
       JSON.stringify({ action: 'created', teamId: data.teamId, name })
     );
+    return;
   }
 
   printSuccess(context, { name });

--- a/src/lib/iam/teams/edit.ts
+++ b/src/lib/iam/teams/edit.ts
@@ -4,6 +4,8 @@ import { failWithError } from '@utils/exit.js';
 import { msg, printStart, printSuccess } from '@utils/messages.js';
 import { getFormat, getOption } from '@utils/options.js';
 
+import { parseMembers } from './shared.js';
+
 const context = msg('iam teams', 'edit');
 
 export default async function edit(options: Record<string, unknown>) {
@@ -14,19 +16,23 @@ export default async function edit(options: Record<string, unknown>) {
   if (isFlyOrganization('Team management')) return;
 
   const id = getOption<string>(options, ['id']);
-  const name = getOption<string>(options, ['name', 'n']);
-  const description = getOption<string>(options, ['description', 'd']);
-  const membersOption = getOption<string | string[]>(options, ['members', 'm']);
 
   if (!id) {
     failWithError(context, 'Team ID is required');
   }
 
-  const members = Array.isArray(membersOption)
-    ? membersOption
-    : membersOption
-      ? [membersOption]
-      : undefined;
+  const nameRaw = getOption<string | boolean>(options, ['name', 'n']);
+  const name = typeof nameRaw === 'string' ? nameRaw : undefined;
+  const descriptionRaw = getOption<string | boolean>(options, [
+    'description',
+    'd',
+  ]);
+  const description =
+    typeof descriptionRaw === 'string' ? descriptionRaw : undefined;
+  const members = parseMembers(
+    context,
+    getOption<string | string[] | boolean>(options, ['members', 'm'])
+  );
 
   if (
     name === undefined &&

--- a/src/lib/iam/teams/edit.ts
+++ b/src/lib/iam/teams/edit.ts
@@ -1,0 +1,63 @@
+import { getOAuthIAMConfig, isFlyOrganization } from '@auth/iam.js';
+import { editTeam } from '@tigrisdata/iam';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+
+const context = msg('iam teams', 'edit');
+
+export default async function edit(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  if (isFlyOrganization('Team management')) return;
+
+  const id = getOption<string>(options, ['id']);
+  const name = getOption<string>(options, ['name', 'n']);
+  const description = getOption<string>(options, ['description', 'd']);
+  const membersOption = getOption<string | string[]>(options, ['members', 'm']);
+
+  if (!id) {
+    failWithError(context, 'Team ID is required');
+  }
+
+  const members = Array.isArray(membersOption)
+    ? membersOption
+    : membersOption
+      ? [membersOption]
+      : undefined;
+
+  if (
+    name === undefined &&
+    description === undefined &&
+    members === undefined
+  ) {
+    failWithError(
+      context,
+      'Provide at least one of --name, --description, or --members to update'
+    );
+  }
+
+  const iamConfig = await getOAuthIAMConfig(context);
+
+  const { error } = await editTeam(
+    id,
+    {
+      ...(name !== undefined ? { name } : {}),
+      ...(description !== undefined ? { description } : {}),
+      ...(members ? { members } : {}),
+    },
+    { config: iamConfig }
+  );
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify({ action: 'updated', teamId: id }));
+  }
+
+  printSuccess(context, { id });
+}

--- a/src/lib/iam/teams/list.ts
+++ b/src/lib/iam/teams/list.ts
@@ -1,0 +1,63 @@
+import { getOAuthIAMConfig, isFlyOrganization } from '@auth/iam.js';
+import { listTeams } from '@tigrisdata/iam';
+import { failWithError } from '@utils/exit.js';
+import {
+  formatJson,
+  formatTable,
+  formatXml,
+  type TableColumn,
+} from '@utils/format.js';
+import { msg, printEmpty, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat } from '@utils/options.js';
+
+const context = msg('iam teams', 'list');
+
+export default async function list(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+
+  if (isFlyOrganization('Team management')) return;
+
+  const iamConfig = await getOAuthIAMConfig(context);
+
+  const { data, error } = await listTeams({
+    config: iamConfig,
+  });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (data.teams.length === 0) {
+    printEmpty(context);
+    return;
+  }
+
+  const rows = data.teams.map((team) => ({
+    id: team.id,
+    name: team.name,
+    description: team.description || '-',
+    members: team.members.length,
+    created: team.createdAt,
+  }));
+
+  const columns: TableColumn[] = [
+    { key: 'id', header: 'ID' },
+    { key: 'name', header: 'Name' },
+    { key: 'description', header: 'Description' },
+    { key: 'members', header: 'Members' },
+    { key: 'created', header: 'Created' },
+  ];
+
+  if (format === 'json') {
+    // Keep the full member list (rows collapse it to a count for tables).
+    console.log(formatJson({ teams: data.teams }));
+  } else if (format === 'xml') {
+    console.log(formatXml(rows, 'teams', 'team'));
+  } else {
+    console.log(formatTable(rows, columns));
+  }
+
+  printSuccess(context, { count: data.teams.length });
+}

--- a/src/lib/iam/teams/shared.ts
+++ b/src/lib/iam/teams/shared.ts
@@ -1,0 +1,29 @@
+import { failWithError } from '@utils/exit.js';
+import type { MessageContext } from '@utils/messages.js';
+
+/**
+ * Normalize the repeatable `--members` flag into a clean list of emails.
+ *
+ * cli-core delivers it as `undefined` (flag omitted), a `string[]` (one or
+ * more comma-separated values), or boolean `true` (the flag passed with no
+ * value). Returns `undefined` when omitted so callers can distinguish "not
+ * provided" from "provided"; errors when the flag is present but carries no
+ * usable value, rather than silently dropping it or forwarding a non-email
+ * (e.g. `true`) to the API.
+ */
+export function parseMembers(
+  context: MessageContext,
+  raw: string | string[] | boolean | undefined
+): string[] | undefined {
+  if (raw === undefined) return undefined;
+
+  const members = (Array.isArray(raw) ? raw : [raw])
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter((value) => value.length > 0);
+
+  if (members.length === 0) {
+    failWithError(context, '--members requires at least one email address');
+  }
+
+  return members;
+}

--- a/src/lib/mk.ts
+++ b/src/lib/mk.ts
@@ -33,6 +33,14 @@ export default async function mk(options: Record<string, unknown>) {
       's',
       'S',
     ]);
+    const allowObjectAcl = getOption<boolean>(options, [
+      'allow-object-acl',
+      'allowObjectAcl',
+    ]);
+    const enableDirectoryListing = getOption<boolean>(options, [
+      'enable-directory-listing',
+      'enableDirectoryListing',
+    ]);
     const defaultTier = getOption<string>(options, [
       'defaultTier',
       'default-tier',
@@ -54,6 +62,8 @@ export default async function mk(options: Record<string, unknown>) {
     const { error } = await createBucket(bucket, {
       defaultTier: (defaultTier ?? 'STANDARD') as StorageClass,
       enableSnapshot: enableSnapshots === true,
+      allowObjectAcl: allowObjectAcl === true,
+      enableDirectoryListing: enableDirectoryListing === true,
       access: (access ?? 'private') as 'public' | 'private',
       locations: parseLocations(locations ?? 'global'),
       ...(forkOf ? { sourceBucketName: forkOf } : {}),

--- a/src/lib/objects/restore-info.ts
+++ b/src/lib/objects/restore-info.ts
@@ -1,0 +1,69 @@
+import { getStorageConfig } from '@auth/provider.js';
+import { getRestoreInfo } from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { formatOutput } from '@utils/format.js';
+import { msg, printEmpty, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+import { resolveObjectArgs } from '@utils/path.js';
+
+const context = msg('objects', 'restore-info');
+
+export default async function restoreInfo(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+  const bucketArg = getOption<string>(options, ['bucket']);
+  const keyArg = getOption<string>(options, ['key']);
+  const versionId = getOption<string>(options, ['version-id', 'versionId']);
+
+  if (!bucketArg) {
+    failWithError(context, 'Bucket name or path is required');
+  }
+
+  const { bucket, key } = resolveObjectArgs(bucketArg, keyArg);
+
+  if (!key) {
+    failWithError(context, 'Object key is required');
+  }
+
+  const config = await getStorageConfig();
+
+  const { data, error } = await getRestoreInfo(key, {
+    ...(versionId ? { versionId } : {}),
+    config: {
+      ...config,
+      bucket,
+    },
+  });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  // undefined means there is nothing to restore — a non-archived object or
+  // one that does not exist. Not an error.
+  if (!data) {
+    if (format === 'json') {
+      console.log(JSON.stringify({ status: null }));
+    } else {
+      printEmpty(context);
+    }
+    return;
+  }
+
+  const info = [
+    { metric: 'Path', value: key },
+    { metric: 'Status', value: data.status },
+    ...(data.expiresAt
+      ? [{ metric: 'Expires', value: data.expiresAt.toISOString() }]
+      : []),
+  ];
+
+  const output = formatOutput(info, format, 'restore-info', 'info', [
+    { key: 'metric', header: 'Metric' },
+    { key: 'value', header: 'Value' },
+  ]);
+
+  console.log(output);
+  printSuccess(context, { bucket, key });
+}

--- a/src/lib/objects/restore.ts
+++ b/src/lib/objects/restore.ts
@@ -1,0 +1,64 @@
+import { getStorageConfig } from '@auth/provider.js';
+import { restoreObject } from '@tigrisdata/storage';
+import { failWithError } from '@utils/exit.js';
+import { msg, printStart, printSuccess } from '@utils/messages.js';
+import { getFormat, getOption } from '@utils/options.js';
+import { resolveObjectArgs } from '@utils/path.js';
+
+const context = msg('objects', 'restore');
+
+export default async function restore(options: Record<string, unknown>) {
+  printStart(context);
+
+  const format = getFormat(options);
+  const bucketArg = getOption<string>(options, ['bucket']);
+  const keyArg = getOption<string>(options, ['key']);
+  const versionId = getOption<string>(options, ['version-id', 'versionId']);
+  const daysArg = getOption<string | number>(options, ['days', 'd']);
+
+  if (!bucketArg) {
+    failWithError(context, 'Bucket name or path is required');
+  }
+
+  const { bucket, key } = resolveObjectArgs(bucketArg, keyArg);
+
+  if (!key) {
+    failWithError(context, 'Object key is required');
+  }
+
+  let days: number | undefined;
+  if (daysArg !== undefined) {
+    days = Number(daysArg);
+    if (!Number.isInteger(days) || days < 1) {
+      failWithError(context, '--days must be a positive integer');
+    }
+  }
+
+  const config = await getStorageConfig();
+
+  const { error } = await restoreObject(key, {
+    ...(days !== undefined ? { days } : {}),
+    ...(versionId ? { versionId } : {}),
+    config: {
+      ...config,
+      bucket,
+    },
+  });
+
+  if (error) {
+    failWithError(context, error);
+  }
+
+  if (format === 'json') {
+    console.log(
+      JSON.stringify({
+        action: 'restore-requested',
+        bucket,
+        key,
+        days: days ?? 1,
+      })
+    );
+  }
+
+  printSuccess(context, { key, bucket });
+}

--- a/src/specs.yaml
+++ b/src/specs.yaml
@@ -1588,6 +1588,62 @@ commands:
             alias: snapshot
           - name: version-id
             description: Object version id (requires bucket versioning). Omit to read the latest version
+      # restore
+      - name: restore
+        description: Restore an archived object (e.g. one in the GLACIER tier) into an actively-readable copy for a number of days
+        alias: rs
+        examples:
+          - "tigris objects restore my-bucket archived.bin"
+          - "tigris objects restore my-bucket archived.bin --days 3"
+          - "tigris objects restore t3://my-bucket/archived.bin --days 7"
+        messages:
+          onStart: 'Requesting restore...'
+          onSuccess: "Restore requested for '{{key}}'"
+          onFailure: 'Failed to restore object'
+        arguments:
+          - name: bucket
+            type: positional
+            required: true
+            description: Name of the bucket, or a full path (t3://bucket/key)
+          - name: key
+            type: positional
+            description: Key of the object (omit if bucket contains the full path)
+          - name: days
+            description: How many days the restored copy stays available before reverting to its archived tier
+            alias: d
+            default: 1
+          - name: version-id
+            description: Restore a specific object version (requires bucket versioning). Omit to restore the current version
+          - name: format
+            description: Output format
+            options: [json, table, xml]
+            default: table
+      # restore-info
+      - name: restore-info
+        description: Show the restore state of an archived object (archived, in-progress, or restored)
+        alias: ri
+        examples:
+          - "tigris objects restore-info my-bucket archived.bin"
+          - "tigris objects restore-info t3://my-bucket/archived.bin --format json"
+        messages:
+          onStart: ''
+          onSuccess: ''
+          onFailure: 'Failed to get restore info'
+          onEmpty: 'No restore information for this object (it is not archived)'
+        arguments:
+          - name: bucket
+            type: positional
+            required: true
+            description: Name of the bucket, or a full path (t3://bucket/key)
+          - name: key
+            type: positional
+            description: Key of the object (omit if bucket contains the full path)
+          - name: version-id
+            description: Inspect a specific object version (requires bucket versioning). Omit to read the current version
+          - name: format
+            description: Output format
+            options: [json, table, xml]
+            default: table
 
   #########################
   # Manage access keys

--- a/src/specs.yaml
+++ b/src/specs.yaml
@@ -2180,3 +2180,78 @@ commands:
               - name: force
                 type: flag
                 description: Skip confirmation prompts (alias for --yes)
+      - name: teams
+        description: Manage organization teams
+        alias: t
+        examples:
+          - "tigris iam teams list"
+          - "tigris iam teams create engineering --members user@example.com"
+          - "tigris iam teams edit team_id --name platform"
+        commands:
+          - name: list
+            description: List all teams in the organization
+            alias: l
+            examples:
+              - "tigris iam teams list"
+              - "tigris iam teams list --format json"
+            messages:
+              onStart: ''
+              onSuccess: ''
+              onFailure: 'Failed to list teams'
+              onEmpty: 'No teams found in this organization'
+            arguments:
+              - name: format
+                description: Output format
+                options: [json, table, xml]
+                default: table
+          - name: create
+            description: Create a new team in the organization
+            alias: c
+            examples:
+              - "tigris iam teams create engineering"
+              - "tigris iam teams create engineering --description 'Engineering team'"
+              - "tigris iam teams create engineering --members a@example.com,b@example.com"
+            messages:
+              onStart: 'Creating team...'
+              onSuccess: "Team '{{name}}' created"
+              onFailure: 'Failed to create team'
+            arguments:
+              - name: name
+                description: Name of the team
+                type: positional
+                required: true
+                examples:
+                  - engineering
+              - name: description
+                description: Description for the team
+                alias: d
+              - name: members
+                description: Member email address(es) to add (comma-separated for multiple)
+                alias: m
+                multiple: true
+          - name: edit
+            description: Update a team's name, description, or members. Members are replaced with the provided list
+            alias: e
+            examples:
+              - "tigris iam teams edit team_id --name platform"
+              - "tigris iam teams edit team_id --description 'Platform team'"
+              - "tigris iam teams edit team_id --members a@example.com,b@example.com"
+            messages:
+              onStart: 'Updating team...'
+              onSuccess: "Team updated"
+              onFailure: 'Failed to update team'
+            arguments:
+              - name: id
+                description: ID of the team to edit
+                type: positional
+                required: true
+              - name: name
+                description: New name for the team
+                alias: n
+              - name: description
+                description: New description for the team
+                alias: d
+              - name: members
+                description: Replace the team's members with these email address(es) (comma-separated for multiple)
+                alias: m
+                multiple: true

--- a/src/specs.yaml
+++ b/src/specs.yaml
@@ -298,6 +298,8 @@ commands:
     examples:
       - "tigris mk my-bucket"
       - "tigris mk my-bucket --access public --region iad"
+      - "tigris mk my-bucket --allow-object-acl"
+      - "tigris mk my-bucket --public --enable-directory-listing"
       - "tigris mk my-bucket/images/"
       - "tigris mk t3://my-bucket"
       - "tigris mk my-fork --fork-of my-bucket"
@@ -325,6 +327,14 @@ commands:
       - name: enable-snapshots
         description: Enable snapshots for the bucket (only applies when creating a bucket)
         alias: s
+        type: flag
+        default: false
+      - name: allow-object-acl
+        description: Allow per-object ACLs on the bucket (only applies when creating a bucket)
+        type: flag
+        default: false
+      - name: enable-directory-listing
+        description: Enable directory listing, relevant for public buckets (only applies when creating a bucket)
         type: flag
         default: false
       - name: default-tier
@@ -447,6 +457,7 @@ commands:
     alias: copy
     examples:
       - "tigris cp ./file.txt t3://my-bucket/file.txt"
+      - "tigris cp ./logo.png t3://my-bucket/logo.png --access public"
       - "tigris cp t3://my-bucket/file.txt ./local-copy.txt"
       - "tigris cp t3://my-bucket/src/ t3://my-bucket/dest/ -r"
       - "tigris cp ./images/ t3://my-bucket/images/ -r"
@@ -476,6 +487,10 @@ commands:
         type: flag
         alias: r
         description: Copy directories recursively
+      - name: access
+        description: Access level for uploaded objects (only applies to local-to-remote uploads)
+        alias: a
+        options: *access_options
 
   # mv
   - name: mv
@@ -699,6 +714,8 @@ commands:
           - "tigris buckets create my-bucket"
           - "tigris buckets create my-bucket --access public --locations iad"
           - "tigris buckets create my-bucket --enable-snapshots --default-tier STANDARD_IA"
+          - "tigris buckets create my-bucket --allow-object-acl"
+          - "tigris buckets create my-bucket --public --enable-directory-listing"
           - "tigris buckets create my-fork --fork-of my-bucket"
           - "tigris buckets create my-fork --fork-of my-bucket --source-snapshot 1765889000501544464"
         messages:
@@ -728,6 +745,14 @@ commands:
           - name: enable-snapshots
             description: Enable snapshots for the bucket
             alias: s
+            type: flag
+            default: false
+          - name: allow-object-acl
+            description: Allow per-object ACLs on the bucket
+            type: flag
+            default: false
+          - name: enable-directory-listing
+            description: Enable directory listing, relevant for public buckets
             type: flag
             default: false
           - name: default-tier

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1894,6 +1894,146 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
     });
   });
 
+  describe('bucket ACL and directory listing', () => {
+    const aclBuckets: string[] = [];
+
+    afterAll(() => {
+      for (const b of aclBuckets) {
+        runCli(`rm ${t3(b)} -f`);
+      }
+    });
+
+    it('mk should create a bucket with --allow-object-acl', () => {
+      const name = `${testPrefix}-acl-mk`;
+      aclBuckets.push(name);
+      const result = runCli(`mk ${name} --allow-object-acl`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('created');
+
+      // buckets get surfaces the setting as "Allow Object ACL: Yes"
+      const info = runCli(`buckets get ${name}`);
+      expect(info.exitCode).toBe(0);
+      expect(info.stdout).toContain('Allow Object ACL');
+      expect(info.stdout).toContain('Yes');
+    });
+
+    it('buckets create should create a bucket with --allow-object-acl', () => {
+      const name = `${testPrefix}-acl-bc`;
+      aclBuckets.push(name);
+      const result = runCli(`buckets create ${name} --allow-object-acl`);
+      expect(result.exitCode).toBe(0);
+
+      const info = runCli(`buckets get ${name}`);
+      expect(info.stdout).toContain('Allow Object ACL');
+      expect(info.stdout).toContain('Yes');
+    });
+
+    it('mk should create a public bucket with --enable-directory-listing', () => {
+      // Directory listing is not surfaced by buckets get, so we only assert
+      // that creation with the flag succeeds.
+      const name = `${testPrefix}-dirlist`;
+      aclBuckets.push(name);
+      const result = runCli(`mk ${name} --public --enable-directory-listing`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('created');
+    });
+  });
+
+  describe('cp command - access', () => {
+    const tmpBase = join(tmpdir(), `cli-test-cpaccess-${testPrefix}`);
+
+    beforeAll(() => {
+      mkdirSync(tmpBase, { recursive: true });
+    });
+
+    afterAll(() => {
+      rmSync(tmpBase, { recursive: true, force: true });
+      runCli(`rm ${t3(testBucket)}/cp-access-pub.txt -f`);
+    });
+
+    it('should upload local->remote with --access public', () => {
+      const tmpFile = join(tmpBase, 'pub.txt');
+      writeFileSync(tmpFile, 'public via cp');
+      const result = runCli(
+        `cp ${tmpFile} ${t3(testBucket)}/cp-access-pub.txt --access public`
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Uploaded');
+    });
+
+    it('should reject --access on remote-to-remote copies', () => {
+      const result = runCli(
+        `cp ${t3(testBucket)}/cp-access-pub.txt ${t3(testBucket)}/cp-access-copy.txt --access public`
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'only applies to local-to-remote uploads'
+      );
+    });
+
+    it('should reject an invalid --access value', () => {
+      const tmpFile = join(tmpBase, 'inv.txt');
+      writeFileSync(tmpFile, 'x');
+      const result = runCli(
+        `cp ${tmpFile} ${t3(testBucket)}/cp-access-inv.txt --access maybe`
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Access level must be either');
+    });
+  });
+
+  describe('objects restore / restore-info', () => {
+    const restoreFile = 'restore-test.txt';
+
+    beforeAll(() => {
+      runCli(`touch ${testBucket}/${restoreFile}`);
+    });
+
+    afterAll(() => {
+      runCli(`rm ${t3(testBucket)}/${restoreFile} -f`);
+    });
+
+    it('restore-info should report no restore info for a non-archived object', () => {
+      const result = runCli(
+        `objects restore-info ${testBucket} ${restoreFile} --format json`
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('"status":null');
+    });
+
+    it('restore should reject a non-positive --days', () => {
+      const result = runCli(
+        `objects restore ${testBucket} ${restoreFile} --days 0`
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--days must be a positive integer');
+    });
+
+    it('restore should reject a non-numeric --days', () => {
+      const result = runCli(
+        `objects restore ${testBucket} ${restoreFile} --days abc`
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--days must be a positive integer');
+    });
+
+    it('restore-info should error when the object key is missing', () => {
+      const result = runCli(`objects restore-info ${testBucket}`);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Object key is required');
+    });
+  });
+
+  describe('iam teams - validation', () => {
+    // Pure CLI validation — fails before any OAuth/network call, so it runs
+    // without OAuth credentials.
+    it('edit should error when no fields are provided', () => {
+      const result = runCli('iam teams edit some-team-id');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Provide at least one of');
+    });
+  });
+
   describe('objects commands with t3:// paths', () => {
     const tmpBase = join(tmpdir(), `cli-test-t3path-${testPrefix}`);
 
@@ -2338,6 +2478,37 @@ describe.skipIf(skipTests || skipOAuth)('OAuth Integration Tests', () => {
       if (result.exitCode === 0 && result.stdout.trim()) {
         expect(() => JSON.parse(result.stdout.trim())).not.toThrow();
       }
+    });
+  });
+
+  describe('iam teams', () => {
+    let createdTeamId: string | undefined;
+    const teamName = `${getTestPrefix()}-team`;
+
+    it('should create a team', () => {
+      const result = runCli(`iam teams create ${teamName} --format json`);
+      // May fail for Fly orgs — that's expected
+      if (result.exitCode === 0 && result.stdout.trim()) {
+        const parsed = JSON.parse(result.stdout.trim()) as { teamId?: string };
+        expect(parsed.teamId).toBeTruthy();
+        createdTeamId = parsed.teamId;
+      }
+    });
+
+    it('should list teams', () => {
+      const result = runCli('iam teams list --format json');
+      if (result.exitCode === 0 && result.stdout.trim()) {
+        expect(() => JSON.parse(result.stdout.trim())).not.toThrow();
+      }
+    });
+
+    it('should edit the created team', () => {
+      // Skip if creation didn't yield an id (e.g. Fly org).
+      if (!createdTeamId) return;
+      const result = runCli(
+        `iam teams edit ${createdTeamId} --name ${teamName}-renamed`
+      );
+      expect(result.exitCode).toBe(0);
     });
   });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2032,6 +2032,18 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Provide at least one of');
     });
+
+    it('create should reject a valueless --members flag', () => {
+      const result = runCli(`iam teams create ${testPrefix}-noval --members`);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('requires at least one email address');
+    });
+
+    it('edit should reject an empty --members value', () => {
+      const result = runCli('iam teams edit some-team-id --members ""');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('requires at least one email address');
+    });
   });
 
   describe('objects commands with t3:// paths', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds org team membership mutations via IAM APIs and new storage restore/ACL upload paths; changes are mostly additive but team `edit --members` is a full replace and dependency bumps widen the SDK surface area.
> 
> **Overview**
> **Release 3.3.0** expands the Tigris CLI with several user-facing capabilities and bumps **`@tigrisdata/iam`** to ^2.2.0 and **`@tigrisdata/storage`** to ^3.16.0.
> 
> **IAM teams** — New `tigris iam teams` subcommands (`list`, `create`, `edit`) call the IAM SDK, skip Fly orgs, and validate `--members` so empty or valueless flags fail before API calls. **`edit` replaces the full member list** when `--members` is set.
> 
> **Archived objects** — `tigris objects restore` and `restore-info` wrap `restoreObject` / `getRestoreInfo` (optional `--days`, `--version-id`, JSON/table output).
> 
> **Buckets** — `mk` and `buckets create` accept **`--allow-object-acl`** and **`--enable-directory-listing`**, passed through to `createBucket`.
> 
> **Copy uploads** — `tigris cp` adds **`--access` (public|private)** for **local-to-remote** uploads only; other copy directions error with guidance to use `objects set-access`.
> 
> Docs (`README.md`, `src/specs.yaml`) and integration tests cover the new flags and commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5925d65ab73604455404f7b7b6b03cb1b1230011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->