### PR TITLE
fix(buckets): read camelCased enable-snapshots flag in create

### DIFF
--- a/src/lib/buckets/create.ts
+++ b/src/lib/buckets/create.ts
@@ -29,6 +29,7 @@ export default async function create(options: Record<string, unknown>) {
     : getOption<string>(options, ['access', 'a', 'A']);
   let enableSnapshots = getOption<boolean>(options, [
     'enable-snapshots',
+    'enableSnapshots',
     's',
     'S',
   ]);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1527,6 +1527,21 @@ describe.skipIf(skipTests)('CLI Integration Tests', () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it('should actually enable snapshots with --enable-snapshots', () => {
+      const name = `${testPrefix}-bc-snap`;
+      bcBuckets.push(name);
+      const result = runCli(`buckets create ${name} --enable-snapshots`);
+      expect(result.exitCode).toBe(0);
+
+      // Regression: --enable-snapshots must actually enable snapshots, not
+      // just create the bucket. The flag arrives camelCased (enableSnapshots)
+      // and was previously not read here, so snapshots stayed off.
+      const info = runCli(`buckets get ${name}`);
+      expect(info.exitCode).toBe(0);
+      expect(info.stdout).toContain('Snapshots Enabled');
+      expect(info.stdout).toContain('Yes');
+    });
+
     it('should error on --source-snapshot without --fork-of', () => {
       const result = runCli(
         `buckets create ${testPrefix}-bc-err --source-snapshot snap1`


### PR DESCRIPTION
## What

`buckets create --enable-snapshots` never enabled snapshots — it created the bucket but silently left snapshots off. (`mk --enable-snapshots` was unaffected.)

## Root cause

Commander passes flags to handlers as camelCase keys, so `--enable-snapshots` arrives as `enableSnapshots`. `buckets/create.ts` looked up only `['enable-snapshots', 's', 'S']` — missing the camelCase key — so the value was always `undefined` and `enableSnapshot: enableSnapshots === true` was always `false`. `mk.ts` already reads the camelCase key, which is why it worked there.

## Fix

Add `'enableSnapshots'` to the `getOption` lookup, matching `mk.ts` and the sibling `enableDirectoryListing`/`sourceSnapshot` reads.

## Test

The existing "create with all flags" integration test passed `--enable-snapshots` but only asserted exit code, so it never caught this. Added a regression test that creates a bucket with `--enable-snapshots` and verifies snapshots are actually enabled via `buckets get`. Verified passing against the live backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small option-parsing fix in bucket create plus a new integration test; behavior change is limited to honoring an existing flag correctly.
> 
> **Overview**
> Fixes **`buckets create --enable-snapshots`** so it actually turns snapshots on instead of succeeding with snapshots still disabled.
> 
> Commander exposes that flag to handlers as **`enableSnapshots`**, but `buckets/create.ts` only looked up kebab-case and short aliases, so the value was always missing and **`enableSnapshot`** was sent as false. The change adds **`enableSnapshots`** to the `getOption` list, consistent with other create flags and with **`mk`**.
> 
> Adds a CLI integration test that creates a bucket with **`--enable-snapshots`** and asserts **`buckets get`** shows snapshots enabled, since the prior “all flags” test only checked exit code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46ab4cbcdd5b7fec03cbe50818b7a770a2b42ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->